### PR TITLE
Feature/#20 handling ctu as context data

### DIFF
--- a/src/app/_rms/interfaces/context/ctu.interface.ts
+++ b/src/app/_rms/interfaces/context/ctu.interface.ts
@@ -3,6 +3,8 @@ import { CountryInterface } from "./country.interface";
 
 export interface CTUInterface {
     id: number;
+    sharepointItemId?: string;
+    source?: string;
     name: string;
     shortName: string;
     addressInfo: string;

--- a/src/app/_rms/services/common/graph-api/graph-api.service.ts
+++ b/src/app/_rms/services/common/graph-api/graph-api.service.ts
@@ -13,7 +13,8 @@ export class GraphApiService {
 
   public SITE_NAME_QUALITY = "Quality";
   public CTU_EVALUATIONS_GUID = "d4cb819a-40b0-4adc-ad14-9aafd4bd5c9d";
-  public CTU_SERVICE_PROVIDERS_GUID = "7C480809-EDA4-4773-936B-0FE9C6284EDE";                                                        
+  public CTU_SERVICE_PROVIDERS_GUID = "7C480809-EDA4-4773-936B-0FE9C6284EDE";
+  public SAS_TRACKER_GUID = "7C480809-EDA4-4773-936B-0FE9C6284EDE";                                                        
 
   private ctuEvaluationsQueryStarted: boolean = false;
   // Stores CTU Evaluations data

--- a/src/app/_rms/services/common/graph-api/graph-api.service.ts
+++ b/src/app/_rms/services/common/graph-api/graph-api.service.ts
@@ -26,7 +26,6 @@ export class GraphApiService {
         this.setCTUEvaluationsData(res);
       });
     }
-
     // const sub = this._ctuEvaluationsData$.subscribe({
     //   next: v => subscriber.next(v),
     //   error: err => subscriber.error(err),
@@ -42,6 +41,7 @@ export class GraphApiService {
     private http: HttpClient,
   ) {
   }
+
 
   
   // TODO: should cache site id for multiple request to the same site
@@ -101,7 +101,6 @@ export class GraphApiService {
     if (!this.ctuServiceProvidersQueryStarted && this._ctusServiceProvidersData$.value === null) {
       this.ctuServiceProvidersQueryStarted = true;
       this.getCTUsServiceProviders().subscribe((res: any) => {
-        console.log('CTU service providers API result =', res);
         this.setCTUsServiceProvidersData(res);
       });
     }
@@ -117,14 +116,14 @@ export class GraphApiService {
       mergeMap((res: any) => {
         if (res?.id) {
           return this.http.get(
-            `https://graph.microsoft.com/v1.0/sites/${res.id}/lists/{${this.CTU_SERVICE_PROVIDERS_GUID}}/items?$expand=fields($select=Title,Short_x0020_Name,Country)`
+            `https://graph.microsoft.com/v1.0/sites/${res.id}/lists/{${this.CTU_SERVICE_PROVIDERS_GUID}}/items?$expand=fields($select=Title,Short_x0020_Name,Country,SAS_x0020_Verification,Address)`
           );
         }
         return of(null);
       })
     );
   }
-
+  
   setCTUsServiceProvidersData(res: any): void {
     let ctus: any[] = [];
 
@@ -135,10 +134,13 @@ export class GraphApiService {
 
           return {
             id: null,
+            sharepointItemId: item?.id || null,
             shortName: fields?.Short_x0020_Name || '',
             name: fields?.Title || '',
+            sasVerification: !!fields?.SAS_x0020_Verification,
+            addressInfo: fields?.Address || null,
             country: {
-              iso2: null,
+              iso2: fields?.Country || null,
               name: fields?.Country || null
             },
             source: 'sharepoint'
@@ -148,14 +150,54 @@ export class GraphApiService {
     }
 
     this._ctusServiceProvidersData$.next(ctus);
-    res?.value?.forEach((item: any, index: number) => {
-      if (index < 5) {
-        console.log('Full SharePoint item =', item);
-        console .log('SharePoint item id =', item?.id);
-        console.log('SharePoint item fields =', item?.fields);
+  }
+
+  downloadCtusServiceProvidersCsv(): void {
+    this.ctusServiceProviders$.subscribe((ctus: any[]) => {
+      if (!ctus || ctus.length === 0) {
+        console.warn('No CTUs to export');
+        return;
       }
+
+      const rows = ctus.map((ctu: any) => ({
+        sharepoint_item_id: ctu.sharepointItemId || '',
+        short_name: ctu.shortName || '',
+        name: ctu.name || '',
+        country_iso2: ctu.country?.iso2 || '',
+        country_name: ctu.country?.name || '',
+        source: ctu.source || ''
+      }));
+
+      const csv = this.convertToCsv(rows);
+      const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+      const url = window.URL.createObjectURL(blob);
+
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = 'ctus_service_providers_with_ids.csv';
+      a.click();
+
+      window.URL.revokeObjectURL(url);
     });
-    console.log('SharePoint raw response =', res);
-    console.log('SharePoint raw items =', res?.value);
+  }
+
+  private convertToCsv(rows: any[]): string {
+    if (!rows || rows.length === 0) {
+      return '';
+    }
+
+    const headers = Object.keys(rows[0]);
+
+    const escapeCsvValue = (value: any): string => {
+      const stringValue = value == null ? '' : String(value);
+      return `"${stringValue.replace(/"/g, '""')}"`;
+    };
+
+    const lines = [
+      headers.join(','),
+      ...rows.map(row => headers.map(header => escapeCsvValue(row[header])).join(','))
+    ];
+
+    return lines.join('\n');
   }
 }

--- a/src/app/_rms/services/common/graph-api/graph-api.service.ts
+++ b/src/app/_rms/services/common/graph-api/graph-api.service.ts
@@ -1,6 +1,6 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { BehaviorSubject, Observable } from 'rxjs';
+import { BehaviorSubject, Observable, of } from 'rxjs';
 import { filter, mergeMap } from 'rxjs/operators';
 import { environment } from 'src/environments/environment';
 
@@ -13,6 +13,7 @@ export class GraphApiService {
 
   public SITE_NAME_QUALITY = "Quality";
   public CTU_EVALUATIONS_GUID = "d4cb819a-40b0-4adc-ad14-9aafd4bd5c9d";
+  public CTU_SERVICE_PROVIDERS_GUID = "7C480809-EDA4-4773-936B-0FE9C6284EDE";                                                        
 
   private ctuEvaluationsQueryStarted: boolean = false;
   // Stores CTU Evaluations data
@@ -42,6 +43,7 @@ export class GraphApiService {
   ) {
   }
 
+  
   // TODO: should cache site id for multiple request to the same site
   getFullSiteId(siteName): Observable<Object> {
     return this.http.get(`https://graph.microsoft.com/v1.0/sites/${environment.sharepointHostname}:/sites/${siteName}?$select=id`);
@@ -79,23 +81,81 @@ export class GraphApiService {
   // getCTUEvaluationData(projectShortName: string, ctuShortName: string) {
   //   return this.ctuEvaluations$.pipe(
   //     mergeMap((ctuEvaluations: Object) => {
-  //       console.log("hello")
-  //       console.log(projectShortName)
-  //       console.log(ctuShortName)
   //       let retArr: [] = [];
 
   //       if (ctuEvaluations && projectShortName && ctuShortName) {
-  //         console.log("first yes");
   //         projectShortName = projectShortName.toLowerCase().trim();
   //         ctuShortName = ctuShortName.toLowerCase().trim();
   //         if (ctuEvaluations.hasOwnProperty(projectShortName)) {
-  //           console.log("second yes");
   //           retArr = ctuEvaluations[projectShortName].filter((fields) => fields?.CTU?.toLowerCase() === ctuShortName);
   //         }
   //       }
-
   //       return of(retArr);
   //     })
   //   )
   // }
+  private ctuServiceProvidersQueryStarted: boolean = false;
+  public _ctusServiceProvidersData$: BehaviorSubject<any[]> = new BehaviorSubject<any[]>(null);
+
+  public ctusServiceProviders$ = new Observable<any[]>(subscriber => {
+    if (!this.ctuServiceProvidersQueryStarted && this._ctusServiceProvidersData$.value === null) {
+      this.ctuServiceProvidersQueryStarted = true;
+      this.getCTUsServiceProviders().subscribe((res: any) => {
+        console.log('CTU service providers API result =', res);
+        this.setCTUsServiceProvidersData(res);
+      });
+    }
+
+    const sub = this._ctusServiceProvidersData$
+      .pipe(filter(v => v !== null))
+      .subscribe(subscriber);
+
+    return () => sub.unsubscribe();
+  });
+  getCTUsServiceProviders(): Observable<any> {
+    return this.getFullSiteId(this.SITE_NAME_QUALITY).pipe(
+      mergeMap((res: any) => {
+        if (res?.id) {
+          return this.http.get(
+            `https://graph.microsoft.com/v1.0/sites/${res.id}/lists/{${this.CTU_SERVICE_PROVIDERS_GUID}}/items?$expand=fields($select=Title,Short_x0020_Name,Country)`
+          );
+        }
+        return of(null);
+      })
+    );
+  }
+
+  setCTUsServiceProvidersData(res: any): void {
+    let ctus: any[] = [];
+
+    if (res?.value?.length > 0) {
+      ctus = res.value
+        .map((item: any) => {
+          const fields = item?.fields || {};
+
+          return {
+            id: null,
+            shortName: fields?.Short_x0020_Name || '',
+            name: fields?.Title || '',
+            country: {
+              iso2: null,
+              name: fields?.Country || null
+            },
+            source: 'sharepoint'
+          };
+        })
+        .filter((ctu: any) => ctu.shortName || ctu.name);
+    }
+
+    this._ctusServiceProvidersData$.next(ctus);
+    res?.value?.forEach((item: any, index: number) => {
+      if (index < 5) {
+        console.log('Full SharePoint item =', item);
+        console .log('SharePoint item id =', item?.id);
+        console.log('SharePoint item fields =', item?.fields);
+      }
+    });
+    console.log('SharePoint raw response =', res);
+    console.log('SharePoint raw items =', res?.value);
+  }
 }

--- a/src/app/_rms/services/context/context.service.ts
+++ b/src/app/_rms/services/context/context.service.ts
@@ -238,6 +238,16 @@ export class ContextService {
       || item.shortName?.toLocaleLowerCase().indexOf(term) > -1
       || item.addressInfo?.toLocaleLowerCase().indexOf(term) > -1;
   }
+  resolveSharePointCtu(payload: {
+    sharepoint_item_id: string | null;
+    name: string | null;
+    short_name: string | null;
+    country_iso2: string | null;
+    sas_verification: boolean;
+    address_info: string | null;
+  }): Observable<any> {
+    return this.http.post(`${environment.baseUrlApi}/context/ctus/resolve-sharepoint`, payload);
+  }
 
   addCTUDropdown(ctuName) {
     const addCTU = this.modalService.open(CtuModalComponent, { size: 'lg', backdrop: 'static' });

--- a/src/app/_rms/services/entities/study-ctu/ctu-mapper.service.ts
+++ b/src/app/_rms/services/entities/study-ctu/ctu-mapper.service.ts
@@ -54,64 +54,45 @@ export class CtuMapperService {
    * - ES
    *
    * This helper ensures country comparison is done on a consistent format.
+   * uses dynamic lookup from countries data instead of hardcoded map.
    */
-  private normalizeCountryCode(value: string): string {
+  private normalizeCountryCode(value: string, countries?: CountryInterface[]): string {
     const raw = this.normalizeText(value).toUpperCase();
-
-    const iso3ToIso2Map: Record<string, string> = {
-      AUT: 'AT',
-      BEL: 'BE',
-      BGR: 'BG',
-      HRV: 'HR',
-      CYP: 'CY',
-      CZE: 'CZ',
-      DNK: 'DK',
-      EST: 'EE',
-      FIN: 'FI',
-      FRA: 'FR',
-      DEU: 'DE',
-      GRC: 'GR',
-      HUN: 'HU',
-      IRL: 'IE',
-      ITA: 'IT',
-      LVA: 'LV',
-      LTU: 'LT',
-      LUX: 'LU',
-      MLT: 'MT',
-      NLD: 'NL',
-      POL: 'PL',
-      PRT: 'PT',
-      ROU: 'RO',
-      SVK: 'SK',
-      SVN: 'SI',
-      ESP: 'ES',
-      SWE: 'SE',
-      CHE: 'CH',
-      NOR: 'NO',
-      ISL: 'IS',
-      GBR: 'GB'
-    };
 
     if (!raw) {
       return '';
     }
 
+    // If already ISO2 format, return as-is
     if (raw.length === 2) {
       return raw;
     }
 
-    return iso3ToIso2Map[raw] || raw;
+    // If countries array is available, use it for dynamic lookup
+    if (countries && countries.length > 0) {
+      const match = countries.find((country) => {
+        const iso3 = this.normalizeText(country?.iso3).toUpperCase();
+        return iso3 === raw;
+      });
+
+      if (match?.iso2) {
+        return match.iso2;
+      }
+    }
+
+    // Fallback: return as-is if not found
+    return raw;
   }
 
   /**
    * Compare two CTU countries in a robust way by normalizing ISO2 / ISO3 codes.
    */
-  private sameCountry(a: any, b: any): boolean {
+  private sameCountry(a: any, b: any, countries?: CountryInterface[]): boolean {
     const aCountryRaw = a?.country?.iso2 || a?.country?.name || '';
     const bCountryRaw = b?.country?.iso2 || b?.country?.name || '';
 
-    const aCountry = this.normalizeCountryCode(aCountryRaw);
-    const bCountry = this.normalizeCountryCode(bCountryRaw);
+    const aCountry = this.normalizeCountryCode(aCountryRaw, countries);
+    const bCountry = this.normalizeCountryCode(bCountryRaw, countries);
 
     return !!aCountry && !!bCountry && aCountry === bCountry;
   }
@@ -135,7 +116,7 @@ export class CtuMapperService {
    * 3. Exact canonical short name match
    * 4. Exact canonical full name match
    */
-  compareCtuOptions(a: any, b: any): boolean {
+  compareCtuOptions(a: any, b: any, countries?: CountryInterface[]): boolean {
     if (!a || !b) {
       return a === b;
     }
@@ -146,7 +127,7 @@ export class CtuMapperService {
     }
 
     // If countries do not match, do not try to match names.
-    if (!this.sameCountry(a, b)) {
+    if (!this.sameCountry(a, b, countries)) {
       return false;
     }
 
@@ -166,12 +147,12 @@ export class CtuMapperService {
   /**
    * Replace an existing DB CTU by its SharePoint equivalent for display purposes.
    */
-  mapExistingCtuToDisplayedCtu(ctu: any, sharePointCtus: any[]): any {
+  mapExistingCtuToDisplayedCtu(ctu: any, sharePointCtus: any[], countries?: CountryInterface[]): any {
     if (!ctu || !sharePointCtus?.length) {
       return ctu;
     }
 
-    const match = sharePointCtus.find((spCtu: any) => this.compareCtuOptions(ctu, spCtu));
+    const match = sharePointCtus.find((spCtu: any) => this.compareCtuOptions(ctu, spCtu, countries));
     return match || ctu;
   }
 
@@ -181,40 +162,6 @@ export class CtuMapperService {
   findCountryIso2FromSharePoint(selectedCtu: any, countries: CountryInterface[]): string | null {
     const rawIso2 = this.normalizeText(selectedCtu?.country?.iso2);
     const rawName = this.normalizeText(selectedCtu?.country?.name);
-
-    const iso3ToIso2Map: Record<string, string> = {
-      aut: 'AT',
-      bel: 'BE',
-      bgr: 'BG',
-      hrv: 'HR',
-      cyp: 'CY',
-      cze: 'CZ',
-      dnk: 'DK',
-      est: 'EE',
-      fin: 'FI',
-      fra: 'FR',
-      deu: 'DE',
-      grc: 'GR',
-      hun: 'HU',
-      irl: 'IE',
-      ita: 'IT',
-      lva: 'LV',
-      ltu: 'LT',
-      lux: 'LU',
-      mlt: 'MT',
-      nld: 'NL',
-      pol: 'PL',
-      prt: 'PT',
-      rou: 'RO',
-      svk: 'SK',
-      svn: 'SI',
-      esp: 'ES',
-      swe: 'SE',
-      che: 'CH',
-      nor: 'NO',
-      isl: 'IS',
-      gbr: 'GB'
-    };
 
     if (!rawIso2 && !rawName) {
       return null;
@@ -230,18 +177,15 @@ export class CtuMapperService {
       return directIso2Match.iso2;
     }
 
-    // 2. Convert ISO3 to ISO2
+    // 2. Convert ISO3 to ISO2 using the countries array
     const iso3Candidate = rawIso2 || rawName;
-    const convertedIso2 = iso3ToIso2Map[iso3Candidate];
+    const iso3Match = countries.find((country) => {
+      const iso3 = this.normalizeText(country?.iso3);
+      return iso3 === iso3Candidate;
+    });
 
-    if (convertedIso2) {
-      const iso2Match = countries.find((country) => {
-        return this.normalizeText(country?.iso2) === this.normalizeText(convertedIso2);
-      });
-
-      if (iso2Match?.iso2) {
-        return iso2Match.iso2;
-      }
+    if (iso3Match?.iso2) {
+      return iso3Match.iso2;
     }
 
     // 3. Match by country name

--- a/src/app/_rms/services/entities/study-ctu/ctu-mapper.service.ts
+++ b/src/app/_rms/services/entities/study-ctu/ctu-mapper.service.ts
@@ -1,0 +1,267 @@
+import { Injectable } from '@angular/core';
+import { CountryInterface } from 'src/app/_rms/interfaces/context/country.interface';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class CtuMapperService {
+
+  /**
+   * Normalize free text for robust comparison.
+   * - lowercase
+   * - remove accents
+   * - remove punctuation
+   * - collapse spaces
+   */
+  normalizeText(value: string): string {
+    if (!value) {
+      return '';
+    }
+
+    return value
+      .toLowerCase()
+      .normalize('NFD')
+      .replace(/[\u0300-\u036f]/g, '')
+      .replace(/[^a-z0-9\s]/g, ' ')
+      .replace(/\s+/g, ' ')
+      .trim();
+  }
+
+  /**
+   * Canonicalize a CTU name by normalizing it and sorting words alphabetically.
+   * This allows matching values such as:
+   * - "CHU ALPES GRENOBLE"
+   * - "CHU GRENOBLE ALPES"
+   */
+  canonicalizeName(value: string): string {
+    const normalized = this.normalizeText(value);
+
+    return normalized
+      .split(' ')
+      .filter(Boolean)
+      .sort()
+      .join(' ');
+  }
+
+  /**
+   * Normalize a country code/name to ISO2 when possible.
+   *
+   * SharePoint sometimes returns ISO3 values such as:
+   * - FRA
+   * - ESP
+   * while DB CTUs usually store ISO2 values such as:
+   * - FR
+   * - ES
+   *
+   * This helper ensures country comparison is done on a consistent format.
+   */
+  private normalizeCountryCode(value: string): string {
+    const raw = this.normalizeText(value).toUpperCase();
+
+    const iso3ToIso2Map: Record<string, string> = {
+      AUT: 'AT',
+      BEL: 'BE',
+      BGR: 'BG',
+      HRV: 'HR',
+      CYP: 'CY',
+      CZE: 'CZ',
+      DNK: 'DK',
+      EST: 'EE',
+      FIN: 'FI',
+      FRA: 'FR',
+      DEU: 'DE',
+      GRC: 'GR',
+      HUN: 'HU',
+      IRL: 'IE',
+      ITA: 'IT',
+      LVA: 'LV',
+      LTU: 'LT',
+      LUX: 'LU',
+      MLT: 'MT',
+      NLD: 'NL',
+      POL: 'PL',
+      PRT: 'PT',
+      ROU: 'RO',
+      SVK: 'SK',
+      SVN: 'SI',
+      ESP: 'ES',
+      SWE: 'SE',
+      CHE: 'CH',
+      NOR: 'NO',
+      ISL: 'IS',
+      GBR: 'GB'
+    };
+
+    if (!raw) {
+      return '';
+    }
+
+    if (raw.length === 2) {
+      return raw;
+    }
+
+    return iso3ToIso2Map[raw] || raw;
+  }
+
+  /**
+   * Compare two CTU countries in a robust way by normalizing ISO2 / ISO3 codes.
+   */
+  private sameCountry(a: any, b: any): boolean {
+    const aCountryRaw = a?.country?.iso2 || a?.country?.name || '';
+    const bCountryRaw = b?.country?.iso2 || b?.country?.name || '';
+
+    const aCountry = this.normalizeCountryCode(aCountryRaw);
+    const bCountry = this.normalizeCountryCode(bCountryRaw);
+
+    return !!aCountry && !!bCountry && aCountry === bCountry;
+  }
+
+  /**
+   * Compare two names after canonicalization.
+   */
+  private exactCanonicalMatch(left: string, right: string): boolean {
+    const leftCanonical = this.canonicalizeName(left);
+    const rightCanonical = this.canonicalizeName(right);
+
+    return !!leftCanonical && !!rightCanonical && leftCanonical === rightCanonical;
+  }
+
+  /**
+   * Compare two CTU options.
+   *
+   * Matching order:
+   * 1. SharePoint ID if both are available
+   * 2. Same normalized country
+   * 3. Exact canonical short name match
+   * 4. Exact canonical full name match
+   */
+  compareCtuOptions(a: any, b: any): boolean {
+    if (!a || !b) {
+      return a === b;
+    }
+
+    // Strongest match: identical SharePoint item id
+    if (a?.sharepointItemId && b?.sharepointItemId) {
+      return String(a.sharepointItemId) === String(b.sharepointItemId);
+    }
+
+    // If countries do not match, do not try to match names.
+    if (!this.sameCountry(a, b)) {
+      return false;
+    }
+
+    // Match by canonical short name
+    if (this.exactCanonicalMatch(a?.shortName, b?.shortName)) {
+      return true;
+    }
+
+    // Match by canonical full name
+    if (this.exactCanonicalMatch(a?.name, b?.name)) {
+      return true;
+    }
+
+    return false;
+  }
+
+  /**
+   * Replace an existing DB CTU by its SharePoint equivalent for display purposes.
+   */
+  mapExistingCtuToDisplayedCtu(ctu: any, sharePointCtus: any[]): any {
+    if (!ctu || !sharePointCtus?.length) {
+      return ctu;
+    }
+
+    const match = sharePointCtus.find((spCtu: any) => this.compareCtuOptions(ctu, spCtu));
+    return match || ctu;
+  }
+
+  /**
+   * Convert a SharePoint country value to a DB ISO2 country code.
+   */
+  findCountryIso2FromSharePoint(selectedCtu: any, countries: CountryInterface[]): string | null {
+    const rawIso2 = this.normalizeText(selectedCtu?.country?.iso2);
+    const rawName = this.normalizeText(selectedCtu?.country?.name);
+
+    const iso3ToIso2Map: Record<string, string> = {
+      aut: 'AT',
+      bel: 'BE',
+      bgr: 'BG',
+      hrv: 'HR',
+      cyp: 'CY',
+      cze: 'CZ',
+      dnk: 'DK',
+      est: 'EE',
+      fin: 'FI',
+      fra: 'FR',
+      deu: 'DE',
+      grc: 'GR',
+      hun: 'HU',
+      irl: 'IE',
+      ita: 'IT',
+      lva: 'LV',
+      ltu: 'LT',
+      lux: 'LU',
+      mlt: 'MT',
+      nld: 'NL',
+      pol: 'PL',
+      prt: 'PT',
+      rou: 'RO',
+      svk: 'SK',
+      svn: 'SI',
+      esp: 'ES',
+      swe: 'SE',
+      che: 'CH',
+      nor: 'NO',
+      isl: 'IS',
+      gbr: 'GB'
+    };
+
+    if (!rawIso2 && !rawName) {
+      return null;
+    }
+
+    // 1. Direct ISO2 match
+    const directIso2Match = countries.find((country) => {
+      const iso2 = this.normalizeText(country?.iso2);
+      return iso2 === rawIso2 || iso2 === rawName;
+    });
+
+    if (directIso2Match?.iso2) {
+      return directIso2Match.iso2;
+    }
+
+    // 2. Convert ISO3 to ISO2
+    const iso3Candidate = rawIso2 || rawName;
+    const convertedIso2 = iso3ToIso2Map[iso3Candidate];
+
+    if (convertedIso2) {
+      const iso2Match = countries.find((country) => {
+        return this.normalizeText(country?.iso2) === this.normalizeText(convertedIso2);
+      });
+
+      if (iso2Match?.iso2) {
+        return iso2Match.iso2;
+      }
+    }
+
+    // 3. Match by country name
+    const byNameMatch = countries.find((country) => {
+      const name = this.normalizeText(country?.name);
+      return name === rawIso2 || name === rawName;
+    });
+
+    return byNameMatch?.iso2 || null;
+  }
+
+  /**
+   * Search helper used by the CTU dropdown.
+   */
+  searchCTUs(term: string, item: any): boolean {
+    const q = this.normalizeText(term);
+    const shortName = this.normalizeText(item?.shortName);
+    const name = this.normalizeText(item?.name);
+    const country = this.normalizeText(item?.country?.name || item?.country?.iso2);
+
+    return shortName.includes(q) || name.includes(q) || country.includes(q);
+  }
+}

--- a/src/app/pages/common/study-ctu/upsert-study-ctu/upsert-study-ctu.component.html
+++ b/src/app/pages/common/study-ctu/upsert-study-ctu/upsert-study-ctu.component.html
@@ -1,3 +1,10 @@
+<!-- <div class="row mb-3" *ngIf="!isView">
+    <div class="col-12 d-flex justify-content-end">
+        <button type="button" class="btn btn-outline-primary" (click)="exportSharePointCtusCsv()">
+            <i class="fa fa-download me-2"></i>Export CTUs CSV
+        </button>
+    </div>
+</div> -->
 <form [formGroup]="form" ngNativeValidate>
     <div formArrayName="studyCTUs">
         <!-- <ng-container *ngIf="!isView; else studyCTUView"> -->
@@ -73,7 +80,7 @@
                         <div class="col-md-12">
                             <div class="row">
                                 <div class="col-md-11">
-                                    <ng-select [items]="sharePointCtus" formControlName="ctu" [searchFn]="searchCTUs" [multiple]="false" [virtualScroll]="true" [compareWith]="compareCtuOptions" notFoundText="No CTUs found" placeholder="Select CTU" (change)="onChangeCTU()" appendTo="body" name="ctu" [ngClass]="{ 'is-invalid': submitted && getControls(i).ctu.errors?.required }">
+                                    <ng-select [items]="displayCtus" formControlName="ctu" [searchFn]="searchCTUs" [multiple]="false" [virtualScroll]="true" [compareWith]="compareCtuOptions" notFoundText="No CTUs found" placeholder="Select CTU" (change)="onChangeCTU()" appendTo="body" name="ctu" [ngClass]="{ 'is-invalid': submitted && getControls(i).ctu.errors?.required }">
                                         <ng-template ng-label-tmp let-item="item">{{item.shortName ? item.shortName + '
                                             - ' : '' }}{{item.name}}</ng-template>
                                         <ng-template ng-option-tmp let-item="item" let-search="searchTerm">

--- a/src/app/pages/common/study-ctu/upsert-study-ctu/upsert-study-ctu.component.html
+++ b/src/app/pages/common/study-ctu/upsert-study-ctu/upsert-study-ctu.component.html
@@ -73,7 +73,7 @@
                         <div class="col-md-12">
                             <div class="row">
                                 <div class="col-md-11">
-                                    <ng-select [items]="ctus" formControlName="ctu" [searchFn]="searchCTUs" [multiple]="false" [virtualScroll]="true" [compareWith]="compareIds" notFoundText="No CTUs found" placeholder="Select CTU" (change)="onChangeCTU()" appendTo="body" name="ctu" [ngClass]="{ 'is-invalid': submitted && getControls(i).ctu.errors?.required }">
+                                    <ng-select [items]="sharePointCtus" formControlName="ctu" [searchFn]="searchCTUs" [multiple]="false" [virtualScroll]="true" [compareWith]="compareCtuOptions" notFoundText="No CTUs found" placeholder="Select CTU" (change)="onChangeCTU()" appendTo="body" name="ctu" [ngClass]="{ 'is-invalid': submitted && getControls(i).ctu.errors?.required }">
                                         <ng-template ng-label-tmp let-item="item">{{item.shortName ? item.shortName + '
                                             - ' : '' }}{{item.name}}</ng-template>
                                         <ng-template ng-option-tmp let-item="item" let-search="searchTerm">

--- a/src/app/pages/common/study-ctu/upsert-study-ctu/upsert-study-ctu.component.ts
+++ b/src/app/pages/common/study-ctu/upsert-study-ctu/upsert-study-ctu.component.ts
@@ -5,8 +5,9 @@ import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import { NgxSpinnerService } from 'ngx-spinner';
 import { ToastrService } from 'ngx-toastr';
 import { Observable, combineLatest, of } from 'rxjs';
-import { catchError, map, mergeMap, startWith } from 'rxjs/operators';
+import { catchError, map, mergeMap } from 'rxjs/operators';
 import { ClassValueInterface } from 'src/app/_rms/interfaces/context/class-value.interface';
+import { CountryInterface } from 'src/app/_rms/interfaces/context/country.interface';
 import { CTUInterface } from 'src/app/_rms/interfaces/context/ctu.interface';
 import { StudyCountryInterface } from 'src/app/_rms/interfaces/core/study-country.interface';
 import { StudyCTUInterface } from 'src/app/_rms/interfaces/core/study-ctus.interface';
@@ -14,7 +15,7 @@ import { BackService } from 'src/app/_rms/services/back/back.service';
 import { GraphApiService } from 'src/app/_rms/services/common/graph-api/graph-api.service';
 import { ContextService } from 'src/app/_rms/services/context/context.service';
 import { StudyCtuService } from 'src/app/_rms/services/entities/study-ctu/study-ctu.service';
-import { anyStringToDateString, dateToString, getFlagEmoji, getTagBgColor, getTagBorderColor, getYYYYMMDDFromDateString } from 'src/assets/js/util';
+import { dateToString, getFlagEmoji, getTagBgColor, getTagBorderColor, getYYYYMMDDFromDateString } from 'src/assets/js/util';
 import { UpsertCentreComponent } from '../../centre/upsert-centre/upsert-centre.component';
 import { ConfirmationWindowComponent } from '../../confirmation-window/confirmation-window.component';
 import { UpsertCtuAgreementComponent } from '../../ctu-agreement/upsert-ctu-agreement/upsert-ctu-agreement.component';
@@ -32,20 +33,23 @@ export class UpsertStudyCtuComponent implements OnInit {
   @Input() studyCountry: StudyCountryInterface;
 
   public ctuEvaluationsListUrl: string = ctuEvaluationsListUrl;
-  static intPatternValidatorFn: ValidatorFn = Validators.pattern("^[0-9]*$");
+  static intPatternValidatorFn: ValidatorFn = Validators.pattern('^[0-9]*$');
 
   id: string;
   form: UntypedFormGroup;
-  submitted: boolean = false;
-  isEdit: boolean = false;
-  isView: boolean = false;
-  isAdd: boolean = false;
-  isSctuPage: boolean = false;
-  ctus: CTUInterface[] = [];
+  submitted = false;
+  isEdit = false;
+  isView = false;
+  isAdd = false;
+  isSctuPage = false;
+
+  sharePointCtus: any[] = [];
+  dbCtus: CTUInterface[] = [];
+  countries: CountryInterface[] = [];
   services: ClassValueInterface[] = [];
   studyCTUs: StudyCTUInterface[] = [];
   ctuEvaluations: any[] = [];
-  loadingCTUEvaluations: boolean = false;
+  loadingCTUEvaluations = false;
 
   constructor(
     private activatedRoute: ActivatedRoute,
@@ -57,7 +61,8 @@ export class UpsertStudyCtuComponent implements OnInit {
     private graphApi: GraphApiService,
     private spinner: NgxSpinnerService,
     private studyCTUService: StudyCtuService,
-    private toastr: ToastrService) {
+    private toastr: ToastrService
+  ) {
     this.form = this.fb.group({
       studyCTUs: this.fb.array([])
     });
@@ -79,15 +84,13 @@ export class UpsertStudyCtuComponent implements OnInit {
     this.isEdit = this.router.url.includes('edit');
     this.isView = this.router.url.includes('view');
 
-    let queryFuncs: Array<Observable<any>> = [];
+    const queryFuncs: Array<Observable<any>> = [];
 
-    // Note: be careful if you add new observables because of the way their result is retrieved later (combineLatest + pop)
-    // The code is built like this because in the version of RxJS used here combineLatest does not handle dictionaries
     if (this.isSctuPage && !this.isAdd) {
       queryFuncs.push(this.getStudyCTU(this.id));
     }
 
-    let obsArr: Array<Observable<any>> = [];
+    const obsArr: Array<Observable<any>> = [];
     queryFuncs.forEach((funct) => {
       obsArr.push(funct.pipe(catchError(error => of(this.toastr.error(error)))));
     });
@@ -103,8 +106,29 @@ export class UpsertStudyCtuComponent implements OnInit {
     });
 
     this.contextService.ctus.subscribe((ctus) => {
-      this.ctus = ctus;
-      if (this.ctus?.length > 0) {
+      this.dbCtus = ctus || [];
+
+      // // Fallback to DB CTUs if SharePoint data is unavailable.
+      if ((!this.sharePointCtus || this.sharePointCtus.length === 0) && this.dbCtus.length > 0) {
+        this.sharePointCtus = [...this.dbCtus];
+        this.sortCTUs();
+      }
+    });
+
+    this.contextService.countries.subscribe((countries) => {
+      this.countries = countries || [];
+    });
+
+    this.graphApi.ctusServiceProviders$.subscribe((ctus) => {
+      console.log('SharePoint CTUs =', ctus);
+      console.log('DB CTUs =', this.dbCtus);
+      if (ctus?.length > 0) {
+        this.sharePointCtus = [...ctus];
+      } else {
+        this.sharePointCtus = [...this.dbCtus];
+      }
+
+      if (this.sharePointCtus?.length > 0) {
         this.sortCTUs();
       }
     });
@@ -114,14 +138,13 @@ export class UpsertStudyCtuComponent implements OnInit {
     });
   }
 
-  get g() { return this.form.get('studyCTUs')["controls"]; }
+  get g() { return this.form.get('studyCTUs')['controls']; }
+  get fv() { return this.getStudyCTUsForm()?.value; }
+  get fc() { return this.getStudyCTUsForm()?.controls; }
 
   getControls(i) {
     return this.g[i].controls;
   }
-
-  get fv() { return this.getStudyCTUsForm()?.value; }
-  get fc() { return this.getStudyCTUsForm()?.controls; }
 
   getStudyCTUsForm(): UntypedFormArray {
     return this.form.get('studyCTUs') as UntypedFormArray;
@@ -132,7 +155,7 @@ export class UpsertStudyCtuComponent implements OnInit {
       id: null,
       leadCtu: false,
       services: [],
-      study: this.studyCountry?.study,  // TODO: verify
+      study: this.studyCountry?.study,
       studyCountry: this.studyCountry,
       ctu: [null, Validators.required],
       ctuAgreements: [],
@@ -146,20 +169,16 @@ export class UpsertStudyCtuComponent implements OnInit {
 
   setStudyCTU(sctuData) {
     if (sctuData) {
-      delete sctuData["statusCode"];
+      delete sctuData['statusCode'];
       this.studyCTUs = [sctuData];
       this.id = sctuData.id;
       this.patchForm();
-      // if (this.ctus?.length > 0) {
-      //   this.sortCTUs();
-      // }
     }
   }
 
   patchForm() {
     this.form.setControl('studyCTUs', this.patchArray());
-
-    this.onChangeCTU(); // Setting CTU Evaluation data
+    this.onChangeCTU();
   }
 
   patchArray(): UntypedFormArray {
@@ -180,58 +199,194 @@ export class UpsertStudyCtuComponent implements OnInit {
   }
 
   sortCTUs() {
-    const countryISO2 = this.studyCountry?.country ? this.studyCountry.country.iso2 : this.form.value.studyCTUs[0]?.studyCountry?.country?.iso2;
-    if (countryISO2) {
-      const { compare } = Intl.Collator('en-GB');
+    const countryISO2 =
+      this.studyCountry?.country?.iso2 ||
+      this.form.value.studyCTUs[0]?.studyCountry?.country?.iso2;
 
-      this.ctus.sort((a, b) => {
-        if (a.country?.iso2?.localeCompare(countryISO2) == 0) {
-          if (b.country?.iso2?.localeCompare(countryISO2) == 0) {
-            return compare(a.shortName + a.name, b.shortName + b.name); // TODO: short name?
-          }
-          return -1;
-        } else if (b.country?.iso2?.localeCompare(countryISO2) == 0) {
-          return 1;
-        } else {  // Sorting by country + name if none of the CTUs match the current country
-          const countryCompare = a.country?.name?.localeCompare(b.country?.name);
-          if (countryCompare > 0) {
-            return 1;
-          } else if (countryCompare < 0) {
-            return -1;
-          } else {
-            return compare(a.shortName + a.name, b.shortName + b.name); // TODO: short name?
-          }
-        }
-      });
+    if (!countryISO2 || !this.sharePointCtus?.length) {
+      return;
     }
+
+    const { compare } = Intl.Collator('en-GB');
+
+    this.sharePointCtus.sort((a, b) => {
+      if (a.country?.iso2?.localeCompare(countryISO2) === 0) {
+        if (b.country?.iso2?.localeCompare(countryISO2) === 0) {
+          return compare((a.shortName || '') + (a.name || ''), (b.shortName || '') + (b.name || ''));
+        }
+        return -1;
+      } else if (b.country?.iso2?.localeCompare(countryISO2) === 0) {
+        return 1;
+      } else {
+        const countryCompare = (a.country?.name || '').localeCompare(b.country?.name || '');
+        if (countryCompare > 0) {
+          return 1;
+        } else if (countryCompare < 0) {
+          return -1;
+        } else {
+          return compare((a.shortName || '') + (a.name || ''), (b.shortName || '') + (b.name || ''));
+        }
+      }
+    });
   }
 
-  // This function removes the explicit newlines characters but does not remove all newlines
+  private normalizeText(value: string): string {
+    return value?.toLowerCase()?.trim() || '';
+  }
+
+  private findCountryIso2FromSharePoint(selectedCtu: any): string | null {
+    const rawIso2 = this.normalizeText(selectedCtu?.country?.iso2);
+    const rawName = this.normalizeText(selectedCtu?.country?.name);
+
+    const iso3ToIso2Map: Record<string, string> = {
+      aut: 'AT',
+      bel: 'BE',
+      bgr: 'BG',
+      hrv: 'HR',
+      cyp: 'CY',
+      cze: 'CZ',
+      dnk: 'DK',
+      est: 'EE',
+      fin: 'FI',
+      fra: 'FR',
+      deu: 'DE',
+      grc: 'GR',
+      hun: 'HU',
+      irl: 'IE',
+      ita: 'IT',
+      lva: 'LV',
+      ltu: 'LT',
+      lux: 'LU',
+      mlt: 'MT',
+      nld: 'NL',
+      pol: 'PL',
+      prt: 'PT',
+      rou: 'RO',
+      svk: 'SK',
+      svn: 'SI',
+      esp: 'ES',
+      swe: 'SE',
+      che: 'CH',
+      nor: 'NO',
+      isl: 'IS',
+      gbr: 'GB'
+    };
+
+    if (!rawIso2 && !rawName) {
+      return null;
+    }
+
+    // 1. direct ISO2
+    const directIso2Match = this.countries.find((country) => {
+      const iso2 = this.normalizeText(country?.iso2);
+      return iso2 === rawIso2 || iso2 === rawName;
+    });
+
+    if (directIso2Match?.iso2) {
+      return directIso2Match.iso2;
+    }
+
+    // 2. ISO3 -> ISO2
+    const iso3Candidate = rawIso2 || rawName;
+    const convertedIso2 = iso3ToIso2Map[iso3Candidate];
+
+    if (convertedIso2) {
+      const iso2Match = this.countries.find((country) => {
+        return this.normalizeText(country?.iso2) === this.normalizeText(convertedIso2);
+      });
+
+      if (iso2Match?.iso2) {
+        return iso2Match.iso2;
+      }
+    }
+
+    // 3. by country name
+    const byNameMatch = this.countries.find((country) => {
+      const name = this.normalizeText(country?.name);
+      return name === rawIso2 || name === rawName;
+    });
+
+    return byNameMatch?.iso2 || null;
+  }
+
+  resolveCtuId(selectedCtu): Observable<number | null> {
+    if (selectedCtu?.id) {
+      return of(selectedCtu.id);
+    }
+
+    const shortName = this.normalizeText(selectedCtu?.shortName);
+    const name = this.normalizeText(selectedCtu?.name);
+    const countryIso2 = this.findCountryIso2FromSharePoint(selectedCtu);
+
+    const existing = this.dbCtus.find((dbCtu) => {
+      const dbCountryIso2 = this.normalizeText(dbCtu?.country?.iso2);
+      const dbShortName = this.normalizeText(dbCtu?.shortName);
+      const dbName = this.normalizeText(dbCtu?.name);
+
+      const sameCountry = dbCountryIso2 === this.normalizeText(countryIso2);
+      const sameShortName = !!shortName && dbShortName === shortName;
+      const sameName = !!name && dbName === name;
+
+      return sameCountry && (sameShortName || sameName);
+    });
+
+    if (existing?.id) {
+      console.log('Matched existing CTU in DB:', existing);
+      return of(existing.id);
+    }
+
+    const payload = {
+      shortName: selectedCtu?.shortName || null,
+      name: selectedCtu?.name || null,
+      country: countryIso2
+    };
+
+    console.log('CTU create payload =', payload);
+    console.log('selectedCtu =', selectedCtu);
+
+    if (!payload.country) {
+      this.toastr.error('Unable to map CTU country from SharePoint to database country.');
+      return of(null);
+    }
+
+    return this.contextService.addCTU(payload).pipe(
+      map((res: any) => {
+        console.log('CTU created =', res);
+        return res?.id || null;
+      }),
+      catchError((err) => {
+        console.log('CTU create error =', err);
+        console.log('CTU create error body =', err?.error);
+        this.toastr.error('Failed to create CTU');
+        return of(null);
+      })
+    );
+  }
+
   cleanAddress(address) {
     if (!address) {
       return null;
     }
-    return address.replace("\n", " ");
+    return address.replace('\n', ' ');
   }
 
-  toggleCTUInfo(event) {  // Unused
-    // TODO: aria-expanded on wrong element?
-    const ctuInfoElement = event.target.closest(".ctuPanel").getElementsByClassName("ctuInfo")[0];
+  toggleCTUInfo(event) {
+    const ctuInfoElement = event.target.closest('.ctuPanel').getElementsByClassName('ctuInfo')[0];
     const expanded = ctuInfoElement.getAttribute('aria-expanded') === 'true';
     ctuInfoElement.setAttribute('aria-expanded', `${!expanded}`);
 
-    if (expanded) { // Reducing
-      ctuInfoElement.classList.add("hideCTUInfo");
-      ctuInfoElement.classList.remove("displayCTUInfo");
+    if (expanded) {
+      ctuInfoElement.classList.add('hideCTUInfo');
+      ctuInfoElement.classList.remove('displayCTUInfo');
 
-      event.target.classList.add("ctuToggleButtonClosed");
-      event.target.classList.remove("ctuToggleButtonOpened");
-    } else {  // Expanding
-      ctuInfoElement.classList.add("displayCTUInfo");
-      ctuInfoElement.classList.remove("hideCTUInfo");
+      event.target.classList.add('ctuToggleButtonClosed');
+      event.target.classList.remove('ctuToggleButtonOpened');
+    } else {
+      ctuInfoElement.classList.add('displayCTUInfo');
+      ctuInfoElement.classList.remove('hideCTUInfo');
 
-      event.target.classList.add("ctuToggleButtonOpened");
-      event.target.classList.remove("ctuToggleButtonClosed");
+      event.target.classList.add('ctuToggleButtonOpened');
+      event.target.classList.remove('ctuToggleButtonClosed');
     }
   }
 
@@ -246,31 +401,6 @@ export class UpsertStudyCtuComponent implements OnInit {
     return getFlagEmoji(iso2);
   }
 
-  // onChangeCTU(i) {  // Unused
-  //   let existingStudyCTU = null;
-  //   for (const sctu of this.studyCTUs) {
-  //     if (sctu?.ctu?.id === this.g[i].value?.ctu?.id) {
-  //       existingStudyCTU = sctu;
-  //       break;
-  //     }
-  //   }
-
-  //   if (existingStudyCTU) {
-  //     delete existingStudyCTU["order"];
-  //     this.getStudyCTUsForm().at(i).setValue(existingStudyCTU);
-  //   } else {
-  //     const ctu = this.g[i].value.ctu;
-  //     this.g[i].reset();
-  //     this.getStudyCTUsForm().at(i).patchValue({ ctu: ctu });
-
-  //     const centreC = this.centreComponents.get(i);
-
-  //     if (centreC.getCentresForm().controls.length == 0) {
-  //       centreC.addCentre();
-  //     }
-  //   }
-  // }
-
   onChangeCTU() {
     this.loadingCTUEvaluations = true;
     this.graphApi.ctuEvaluations$.subscribe((ctuEvaluations) => {
@@ -278,27 +408,30 @@ export class UpsertStudyCtuComponent implements OnInit {
         const projectShortName = fv.study?.project?.shortName?.toLowerCase()?.trim();
         const ctuShortName = fv.ctu?.shortName?.toLowerCase()?.trim();
         if (projectShortName && ctuShortName && ctuEvaluations[projectShortName]) {
-          this.ctuEvaluations[i] = ctuEvaluations[projectShortName].filter((fields) => fields?.CTU?.toLowerCase() === ctuShortName);
+          this.ctuEvaluations[i] = ctuEvaluations[projectShortName].filter(
+            (fields) => fields?.CTU?.toLowerCase() === ctuShortName
+          );
         } else {
           this.ctuEvaluations[i] = [];
         }
       }
 
       this.sortCTUEvaluations();
-
       this.loadingCTUEvaluations = false;
     });
   }
 
   sortCTUEvaluations() {
-    this.ctuEvaluations.sort((a,b) => (a.Created > b.Created) ? 1 : ((b.Created > a.Created) ? -1 : 0))
+    this.ctuEvaluations.sort((a, b) =>
+      (a.Created > b.Created) ? 1 : ((b.Created > a.Created) ? -1 : 0)
+    );
   }
 
   getCTUEvaluationResult(i) {
     if (this.ctuEvaluations[i]?.length > 0) {
       return this.ctuEvaluations[i][0]?.Result;
     } else if (this.loadingCTUEvaluations) {
-      return "Loading...";
+      return 'Loading...';
     }
     return null;
   }
@@ -307,22 +440,22 @@ export class UpsertStudyCtuComponent implements OnInit {
     if (this.ctuEvaluations[i]?.length > 0) {
       return `(${getYYYYMMDDFromDateString(this.ctuEvaluations[i][0]?.Created)})`;
     } else if (this.loadingCTUEvaluations) {
-      return "Loading...";
+      return 'Loading...';
     }
-    return "";
+    return '';
   }
 
   getCTUEvaluationTagClass(i) {
-    let tagClass = "";
+    let tagClass = '';
     const resultText = this.getCTUEvaluationResult(i)?.toLowerCase().trim();
 
     if (resultText) {
       if (resultText === CtuEvaluationResults.SATISFACTORY?.toLowerCase()) {
-        tagClass = "tag-success";
+        tagClass = 'tag-success';
       } else if (resultText === CtuEvaluationResults.NEEDS_IMPROVEMENT?.toLowerCase()) {
-        tagClass = "tag-warning";
+        tagClass = 'tag-warning';
       } else if (resultText === CtuEvaluationResults.UNSATISFACTORY?.toLowerCase()) {
-        tagClass = "tag-danger";
+        tagClass = 'tag-danger';
       }
     }
     return tagClass;
@@ -353,19 +486,20 @@ export class UpsertStudyCtuComponent implements OnInit {
   }
 
   deleteService($event, sToRemove) {
-    $event.stopPropagation(); // Clicks the option otherwise
+    $event.stopPropagation();
 
-    if (sToRemove.id == -1) {  // Created locally by user
+    if (sToRemove.id == -1) {
       this.services = this.services.filter(s => !(s.id == sToRemove.id && s.value == sToRemove.value));
-    } else {  // Already existing
+    } else {
       this.contextService.deleteServiceDropdown(sToRemove, !this.isAdd);
     }
   }
 
   ngOnChanges(changes: SimpleChanges) {
     let patchForm = false;
+
     if (changes.studyCountry?.previousValue?.country?.iso2 != changes.studyCountry?.currentValue?.country?.iso2) {
-      if (this.ctus?.length > 0) {
+      if (this.sharePointCtus?.length > 0) {
         this.sortCTUs();
       }
       patchForm = true;
@@ -390,22 +524,20 @@ export class UpsertStudyCtuComponent implements OnInit {
   }
 
   deleteStudyCTU($event, i: number) {
-    $event.stopPropagation(); // Expands the panel otherwise
+    $event.stopPropagation();
 
     const sctuId = this.getStudyCTUsForm().value[i].id;
-    if (!sctuId) { // Study CTU has been locally added only
+    if (!sctuId) {
       this.getStudyCTUsForm().removeAt(i);
-    } else {  // Existing study CTU
+    } else {
       const removeModal = this.modalService.open(ConfirmationWindowComponent, { size: 'lg', backdrop: 'static' });
-      removeModal.componentInstance.setDefaultDeleteMessage("study CTU");
+      removeModal.componentInstance.setDefaultDeleteMessage('study CTU');
 
       removeModal.result.then((remove) => {
         if (remove) {
           this.studyCTUService.deleteStudyCTU(sctuId).subscribe((res: any) => {
             if (res.status === 204) {
               this.getStudyCTUsForm().removeAt(i);
-
-              // Removing study CTU from studyCTUs list, otherwise there will be a failing API call to delete it on save
               this.studyCTUs = this.studyCTUs.filter((item: any) => item.id != sctuId);
               this.toastr.success('Study CTU deleted successfully');
             } else {
@@ -415,22 +547,21 @@ export class UpsertStudyCtuComponent implements OnInit {
             this.toastr.error(error);
           });
         }
-      }, error => { this.toastr.error(error) });
+      }, error => { this.toastr.error(error); });
     }
   }
 
   isFormValid() {
     this.submitted = true;
 
-    // Manually checking CTU field (shouldn't be empty)
-    for (const i in this.form.get("studyCTUs")['controls']) {
-      if (this.form.get("studyCTUs")['controls'][i].value.ctu == null) {
-        this.form.get("studyCTUs")['controls'][i].controls.ctu.setErrors({ 'required': true });
+    for (const i in this.form.get('studyCTUs')['controls']) {
+      if (this.form.get('studyCTUs')['controls'][i].value.ctu == null) {
+        this.form.get('studyCTUs')['controls'][i].controls.ctu.setErrors({ required: true });
       }
     }
 
     if (!this.form.valid) {
-      this.toastr.error("Please correct the errors in the study CTUs form");
+      this.toastr.error('Please correct the errors in the study CTUs form');
     }
 
     return this.form.valid && !this.centreComponents.some(b => !b.isFormValid());
@@ -462,7 +593,6 @@ export class UpsertStudyCtuComponent implements OnInit {
       payload.services = [];
     }
 
-    // Note: needs to be changed if possible to add a new study CTU not from the higher level pages
     if (!this.isSctuPage) {
       payload.order = i;
     }
@@ -470,69 +600,87 @@ export class UpsertStudyCtuComponent implements OnInit {
 
   onSave(scId: string, studyId: string): Observable<boolean[]> {
     this.submitted = true;
-    let saveObs$: Array<Observable<boolean>> = [];
-
+    const saveObs$: Array<Observable<boolean>> = [];
     const payload = JSON.parse(JSON.stringify(this.form.value));
 
     for (const [i, item] of payload.studyCTUs.entries()) {
-      this.updatePayload(item, scId, studyId, i);
+      saveObs$.push(
+        this.resolveCtuId(item.ctu).pipe(
+          mergeMap((ctuId: number | null) => {
+            if (!ctuId) {
+              return of(false);
+            }
 
-      let itemObs$: Observable<Object> = null;
+            item.ctu = { id: ctuId };
+            this.updatePayload(item, scId, studyId, i);
 
-      if (!item.id) {  // Add
-        itemObs$ = this.studyCTUService.addStudyCTUFromStudy(studyId, item)
-      } else {
-        itemObs$ = this.studyCTUService.editStudyCTU(item.id, item);
-      }
+            let itemObs$: Observable<Object>;
+            if (!item.id) {
+              itemObs$ = this.studyCTUService.addStudyCTUFromStudy(studyId, item);
+            } else {
+              itemObs$ = this.studyCTUService.editStudyCTU(item.id, item);
+            }
 
-      saveObs$.push(itemObs$.pipe(
-        mergeMap((res: any) => {
-          if ((!item.id && res.statusCode === 201) || (item.id && res.statusCode === 200)) {
-            let subObs$: Observable<boolean>[] = [];
+            return itemObs$.pipe(
+              mergeMap((res: any) => {
+                if ((!item.id && res.statusCode === 201) || (item.id && res.statusCode === 200)) {
+                  const subObs$: Observable<boolean>[] = [];
 
-            subObs$.push(this.centreComponents.get(i).onSave(res.id, studyId).pipe(
-              map((successArr: boolean[]) => {
-                return successArr.every(a => a);
-              })
-            ));
+                  subObs$.push(
+                    this.centreComponents.get(i).onSave(res.id, studyId).pipe(
+                      map((successArr: boolean[]) => successArr.every(a => a))
+                    )
+                  );
 
-            subObs$.push(this.ctuAgreementComponents.get(i).onSave(res.id).pipe(
-              map((successArr: boolean[]) => {
-                return successArr.every(a => a);
-              })
-            ));
+                  subObs$.push(
+                    this.ctuAgreementComponents.get(i).onSave(res.id).pipe(
+                      map((successArr: boolean[]) => successArr.every(a => a))
+                    )
+                  );
 
-            return combineLatest(subObs$).pipe(
-              map((successArr: boolean[]) => {
-                return successArr.every(a => a);
+                  return combineLatest(subObs$).pipe(
+                    map((successArr: boolean[]) => successArr.every(a => a))
+                  );
+                }
+
+                this.toastr.error('Failed to save Study CTU');
+                return of(false);
+              }),
+              catchError((err) => {
+                this.toastr.error(err);
+                return of(false);
               })
             );
-          }
-          this.toastr.error("Failed to save Study CTU");
-          return of(false);
-        })
-      ))
+          }),
+          catchError((err) => {
+            this.toastr.error(err);
+            return of(false);
+          })
+        )
+      );
     }
 
-    // Used to check for study CTUs that have been "soft deleted" from the interface, 
-    // as in by switching CTU for an existing study CTU rather than deleting the study CTU and making a new one
-    const formIds: Array<String> = payload.studyCTUs.map((item: StudyCTUInterface) => { return item.id; });
-    const removedItems: Array<StudyCTUInterface> = this.studyCTUs.filter((previousItem: StudyCTUInterface) => formIds.indexOf(previousItem.id) < 0);
+    const formIds: Array<String> = payload.studyCTUs.map((item: StudyCTUInterface) => item.id);
+    const removedItems: Array<StudyCTUInterface> = this.studyCTUs.filter(
+      (previousItem: StudyCTUInterface) => formIds.indexOf(previousItem.id) < 0
+    );
 
-    // Deleting items removed in the UI
     removedItems.forEach((sctu: StudyCTUInterface) => {
-      saveObs$.push(this.studyCTUService.deleteStudyCTU(sctu.id).pipe(
-        mergeMap((res: any) => {
-          if (res.status === 204) {
-            return of(true);
-          } else {
-            this.toastr.error(res);
+      saveObs$.push(
+        this.studyCTUService.deleteStudyCTU(sctu.id).pipe(
+          mergeMap((res: any) => {
+            if (res.status === 204) {
+              return of(true);
+            } else {
+              this.toastr.error(res);
+              return of(false);
+            }
+          }),
+          catchError(err => {
+            this.toastr.error(err);
             return of(false);
-          }
-        }), catchError(err => {
-          this.toastr.error(err);
-          return of(false);
-        }))
+          })
+        )
       );
     });
 
@@ -552,8 +700,8 @@ export class UpsertStudyCtuComponent implements OnInit {
       if (scId && studyId) {
         this.onSave(scId, studyId).subscribe((success) => {
           this.spinner.hide();
-          if (success) {
-            this.toastr.success("Changes saved successfully");
+          if (success.every(s => s)) {
+            this.toastr.success('Changes saved successfully');
             this.router.navigate([`/study-ctus/${this.id}/view`]);
           }
         });
@@ -561,6 +709,8 @@ export class UpsertStudyCtuComponent implements OnInit {
         this.spinner.hide();
         this.toastr.error("Couldn't get study and/or study country ID from study CTU");
       }
+    } else {
+      this.spinner.hide();
     }
   }
 
@@ -572,9 +722,33 @@ export class UpsertStudyCtuComponent implements OnInit {
     return fv1?.id == fv2?.id;
   }
 
-  searchCTUs = (term: string, item) => {
-    return this.contextService.searchCTUs(term, item);
-  }
+  compareCtuOptions = (a: any, b: any): boolean => {
+    if (!a || !b) {
+      return a === b;
+    }
+
+    if (a.id && b.id) {
+      return a.id === b.id;
+    }
+
+    const aShort = this.normalizeText(a.shortName);
+    const bShort = this.normalizeText(b.shortName);
+    const aName = this.normalizeText(a.name);
+    const bName = this.normalizeText(b.name);
+    const aCountry = this.normalizeText(a?.country?.iso2 || a?.country?.name);
+    const bCountry = this.normalizeText(b?.country?.iso2 || b?.country?.name);
+
+    return aCountry === bCountry && ((aShort && aShort === bShort) || (aName && aName === bName));
+  };
+
+  searchCTUs = (term: string, item: any) => {
+    const q = this.normalizeText(term);
+    const shortName = this.normalizeText(item?.shortName);
+    const name = this.normalizeText(item?.name);
+    const country = this.normalizeText(item?.country?.name || item?.country?.iso2);
+
+    return shortName.includes(q) || name.includes(q) || country.includes(q);
+  };
 
   back(): void {
     this.backService.back();

--- a/src/app/pages/common/study-ctu/upsert-study-ctu/upsert-study-ctu.component.ts
+++ b/src/app/pages/common/study-ctu/upsert-study-ctu/upsert-study-ctu.component.ts
@@ -756,7 +756,7 @@ export class UpsertStudyCtuComponent implements OnInit {
       return ctu;
     }
 
-    const sharePointMatch = this.ctuMapperService.mapExistingCtuToDisplayedCtu(ctu, this.sharePointCtus);
+    const sharePointMatch = this.ctuMapperService.mapExistingCtuToDisplayedCtu(ctu, this.sharePointCtus, this.countries);
 
     if (sharePointMatch && (sharePointMatch?.sharepointItemId || sharePointMatch?.source === 'sharepoint')) {
       return sharePointMatch;
@@ -775,7 +775,7 @@ export class UpsertStudyCtuComponent implements OnInit {
     }
 
     const match = this.sharePointCtus?.find((spCtu: any) => {
-      return this.ctuMapperService.compareCtuOptions(ctu, spCtu);
+      return this.ctuMapperService.compareCtuOptions(ctu, spCtu, this.countries);
     });
 
 
@@ -791,7 +791,7 @@ export class UpsertStudyCtuComponent implements OnInit {
   }
 
   compareCtuOptions = (a: any, b: any): boolean => {
-    return this.ctuMapperService.compareCtuOptions(a, b);
+    return this.ctuMapperService.compareCtuOptions(a, b, this.countries);
   };
 
   searchCTUs = (term: string, item: any) => {

--- a/src/app/pages/common/study-ctu/upsert-study-ctu/upsert-study-ctu.component.ts
+++ b/src/app/pages/common/study-ctu/upsert-study-ctu/upsert-study-ctu.component.ts
@@ -171,6 +171,20 @@ export class UpsertStudyCtuComponent implements OnInit {
       // Keep only real SharePoint data here.
       this.sharePointCtus = ctus?.length > 0 ? [...ctus] : [];
 
+      // Fix country ISO2 for SharePoint CTUs if they have ISO3 codes
+      this.sharePointCtus.forEach(ctu => {
+        if (ctu.country?.iso2 && this.countries?.length > 0) {
+          const correctIso2 = this.ctuMapperService.findCountryIso2FromSharePoint(ctu, this.countries);
+          if (correctIso2 && correctIso2 !== ctu.country.iso2) {
+            ctu.country.iso2 = correctIso2;
+            const countryMatch = this.countries.find(c => c.iso2 === correctIso2);
+            if (countryMatch) {
+              ctu.country.name = countryMatch.name;
+            }
+          }
+        }
+      });
+
       // Display SharePoint CTUs when available, otherwise fallback to DB CTUs.
       this.displayCtus = this.sharePointCtus.length > 0
         ? [...this.sharePointCtus]

--- a/src/app/pages/common/study-ctu/upsert-study-ctu/upsert-study-ctu.component.ts
+++ b/src/app/pages/common/study-ctu/upsert-study-ctu/upsert-study-ctu.component.ts
@@ -6,16 +6,27 @@ import { NgxSpinnerService } from 'ngx-spinner';
 import { ToastrService } from 'ngx-toastr';
 import { Observable, combineLatest, of } from 'rxjs';
 import { catchError, map, mergeMap } from 'rxjs/operators';
+
 import { ClassValueInterface } from 'src/app/_rms/interfaces/context/class-value.interface';
 import { CountryInterface } from 'src/app/_rms/interfaces/context/country.interface';
 import { CTUInterface } from 'src/app/_rms/interfaces/context/ctu.interface';
 import { StudyCountryInterface } from 'src/app/_rms/interfaces/core/study-country.interface';
 import { StudyCTUInterface } from 'src/app/_rms/interfaces/core/study-ctus.interface';
+
 import { BackService } from 'src/app/_rms/services/back/back.service';
 import { GraphApiService } from 'src/app/_rms/services/common/graph-api/graph-api.service';
 import { ContextService } from 'src/app/_rms/services/context/context.service';
 import { StudyCtuService } from 'src/app/_rms/services/entities/study-ctu/study-ctu.service';
-import { dateToString, getFlagEmoji, getTagBgColor, getTagBorderColor, getYYYYMMDDFromDateString } from 'src/assets/js/util';
+import { CtuMapperService } from 'src/app/_rms/services/entities/study-ctu/ctu-mapper.service';
+
+import {
+  dateToString,
+  getFlagEmoji,
+  getTagBgColor,
+  getTagBorderColor,
+  getYYYYMMDDFromDateString
+} from 'src/assets/js/util';
+
 import { UpsertCentreComponent } from '../../centre/upsert-centre/upsert-centre.component';
 import { ConfirmationWindowComponent } from '../../confirmation-window/confirmation-window.component';
 import { UpsertCtuAgreementComponent } from '../../ctu-agreement/upsert-ctu-agreement/upsert-ctu-agreement.component';
@@ -43,8 +54,15 @@ export class UpsertStudyCtuComponent implements OnInit {
   isAdd = false;
   isSctuPage = false;
 
+  // Real SharePoint CTUs only
   sharePointCtus: any[] = [];
+
+  // Fallback DB CTUs
   dbCtus: CTUInterface[] = [];
+
+  // CTUs displayed in the dropdown: SharePoint if available, DB otherwise
+  displayCtus: any[] = [];
+
   countries: CountryInterface[] = [];
   services: ClassValueInterface[] = [];
   studyCTUs: StudyCTUInterface[] = [];
@@ -61,6 +79,7 @@ export class UpsertStudyCtuComponent implements OnInit {
     private graphApi: GraphApiService,
     private spinner: NgxSpinnerService,
     private studyCTUService: StudyCtuService,
+    private ctuMapperService: CtuMapperService,
     private toastr: ToastrService
   ) {
     this.form = this.fb.group({
@@ -69,6 +88,15 @@ export class UpsertStudyCtuComponent implements OnInit {
   }
 
   ngOnInit(): void {
+    this.initPageFlags();
+    this.loadInitialStudyCtuIfNeeded();
+    this.subscribeToDbCtus();
+    this.subscribeToCountries();
+    this.subscribeToSharePointCtus();
+    this.subscribeToServices();
+  }
+
+  private initPageFlags(): void {
     if (this.router.url.includes('study-ctus')) {
       this.id = this.activatedRoute.snapshot.params.id;
       this.isSctuPage = true;
@@ -83,11 +111,20 @@ export class UpsertStudyCtuComponent implements OnInit {
     this.isAdd = this.router.url.includes('add');
     this.isEdit = this.router.url.includes('edit');
     this.isView = this.router.url.includes('view');
+  }
 
+  private loadInitialStudyCtuIfNeeded(): void {
     const queryFuncs: Array<Observable<any>> = [];
 
     if (this.isSctuPage && !this.isAdd) {
       queryFuncs.push(this.getStudyCTU(this.id));
+    }
+
+    if (queryFuncs.length === 0) {
+      setTimeout(() => {
+        this.spinner.hide();
+      });
+      return;
     }
 
     const obsArr: Array<Observable<any>> = [];
@@ -104,35 +141,51 @@ export class UpsertStudyCtuComponent implements OnInit {
         this.spinner.hide();
       });
     });
+  }
 
+  private subscribeToDbCtus(): void {
     this.contextService.ctus.subscribe((ctus) => {
       this.dbCtus = ctus || [];
 
-      // // Fallback to DB CTUs if SharePoint data is unavailable.
-      if ((!this.sharePointCtus || this.sharePointCtus.length === 0) && this.dbCtus.length > 0) {
-        this.sharePointCtus = [...this.dbCtus];
+      // Use DB data only as a display fallback.
+      // Do not copy DB CTUs into sharePointCtus.
+      if ((!this.displayCtus || this.displayCtus.length === 0) && this.dbCtus.length > 0) {
+        this.displayCtus = [...this.dbCtus];
         this.sortCTUs();
       }
     });
+  }
 
+  private subscribeToCountries(): void {
     this.contextService.countries.subscribe((countries) => {
       this.countries = countries || [];
     });
+  }
 
+  private subscribeToSharePointCtus(): void {
     this.graphApi.ctusServiceProviders$.subscribe((ctus) => {
-      console.log('SharePoint CTUs =', ctus);
-      console.log('DB CTUs =', this.dbCtus);
-      if (ctus?.length > 0) {
-        this.sharePointCtus = [...ctus];
-      } else {
-        this.sharePointCtus = [...this.dbCtus];
-      }
 
-      if (this.sharePointCtus?.length > 0) {
+      // Keep only real SharePoint data here.
+      this.sharePointCtus = ctus?.length > 0 ? [...ctus] : [];
+
+      // Display SharePoint CTUs when available, otherwise fallback to DB CTUs.
+      this.displayCtus = this.sharePointCtus.length > 0
+        ? [...this.sharePointCtus]
+        : [...this.dbCtus];
+
+      if (this.displayCtus?.length > 0) {
         this.sortCTUs();
+
+        // Re-patch the form so existing DB CTUs can be replaced by
+        // their SharePoint version when SharePoint data is available.
+        if (this.studyCTUs?.length > 0) {
+          this.patchForm();
+        }
       }
     });
+  }
 
+  private subscribeToServices(): void {
     this.contextService.services.subscribe((services) => {
       this.services = services;
     });
@@ -190,7 +243,7 @@ export class UpsertStudyCtuComponent implements OnInit {
         services: [sctu.services],
         study: sctu.study,
         studyCountry: sctu.studyCountry,
-        ctu: sctu.ctu,
+        ctu: this.mapExistingCtuToDisplayedCtu(sctu.ctu),
         ctuAgreements: [sctu.ctuAgreements],
         centres: [sctu.centres]
       }));
@@ -203,13 +256,13 @@ export class UpsertStudyCtuComponent implements OnInit {
       this.studyCountry?.country?.iso2 ||
       this.form.value.studyCTUs[0]?.studyCountry?.country?.iso2;
 
-    if (!countryISO2 || !this.sharePointCtus?.length) {
+    if (!countryISO2 || !this.displayCtus?.length) {
       return;
     }
 
     const { compare } = Intl.Collator('en-GB');
 
-    this.sharePointCtus.sort((a, b) => {
+    this.displayCtus.sort((a, b) => {
       if (a.country?.iso2?.localeCompare(countryISO2) === 0) {
         if (b.country?.iso2?.localeCompare(countryISO2) === 0) {
           return compare((a.shortName || '') + (a.name || ''), (b.shortName || '') + (b.name || ''));
@@ -230,134 +283,47 @@ export class UpsertStudyCtuComponent implements OnInit {
     });
   }
 
-  private normalizeText(value: string): string {
-    return value?.toLowerCase()?.trim() || '';
-  }
-
-  private findCountryIso2FromSharePoint(selectedCtu: any): string | null {
-    const rawIso2 = this.normalizeText(selectedCtu?.country?.iso2);
-    const rawName = this.normalizeText(selectedCtu?.country?.name);
-
-    const iso3ToIso2Map: Record<string, string> = {
-      aut: 'AT',
-      bel: 'BE',
-      bgr: 'BG',
-      hrv: 'HR',
-      cyp: 'CY',
-      cze: 'CZ',
-      dnk: 'DK',
-      est: 'EE',
-      fin: 'FI',
-      fra: 'FR',
-      deu: 'DE',
-      grc: 'GR',
-      hun: 'HU',
-      irl: 'IE',
-      ita: 'IT',
-      lva: 'LV',
-      ltu: 'LT',
-      lux: 'LU',
-      mlt: 'MT',
-      nld: 'NL',
-      pol: 'PL',
-      prt: 'PT',
-      rou: 'RO',
-      svk: 'SK',
-      svn: 'SI',
-      esp: 'ES',
-      swe: 'SE',
-      che: 'CH',
-      nor: 'NO',
-      isl: 'IS',
-      gbr: 'GB'
-    };
-
-    if (!rawIso2 && !rawName) {
-      return null;
+  resolveCtuId(selectedCtu: any): Observable<number | null> {
+    if (!selectedCtu) {
+      return of(null);
     }
 
-    // 1. direct ISO2
-    const directIso2Match = this.countries.find((country) => {
-      const iso2 = this.normalizeText(country?.iso2);
-      return iso2 === rawIso2 || iso2 === rawName;
-    });
+    const fallbackDbId = selectedCtu?.id || null;
 
-    if (directIso2Match?.iso2) {
-      return directIso2Match.iso2;
-    }
+    // Always try to use the real SharePoint version when possible.
+    const ctuToResolve = this.getSharePointVersionOfCtu(selectedCtu) || selectedCtu;
 
-    // 2. ISO3 -> ISO2
-    const iso3Candidate = rawIso2 || rawName;
-    const convertedIso2 = iso3ToIso2Map[iso3Candidate];
+    const countryIso2 = this.ctuMapperService.findCountryIso2FromSharePoint(ctuToResolve, this.countries);
 
-    if (convertedIso2) {
-      const iso2Match = this.countries.find((country) => {
-        return this.normalizeText(country?.iso2) === this.normalizeText(convertedIso2);
-      });
-
-      if (iso2Match?.iso2) {
-        return iso2Match.iso2;
+    if (!countryIso2) {
+      if (fallbackDbId) {
+        return of(fallbackDbId);
       }
-    }
 
-    // 3. by country name
-    const byNameMatch = this.countries.find((country) => {
-      const name = this.normalizeText(country?.name);
-      return name === rawIso2 || name === rawName;
-    });
-
-    return byNameMatch?.iso2 || null;
-  }
-
-  resolveCtuId(selectedCtu): Observable<number | null> {
-    if (selectedCtu?.id) {
-      return of(selectedCtu.id);
-    }
-
-    const shortName = this.normalizeText(selectedCtu?.shortName);
-    const name = this.normalizeText(selectedCtu?.name);
-    const countryIso2 = this.findCountryIso2FromSharePoint(selectedCtu);
-
-    const existing = this.dbCtus.find((dbCtu) => {
-      const dbCountryIso2 = this.normalizeText(dbCtu?.country?.iso2);
-      const dbShortName = this.normalizeText(dbCtu?.shortName);
-      const dbName = this.normalizeText(dbCtu?.name);
-
-      const sameCountry = dbCountryIso2 === this.normalizeText(countryIso2);
-      const sameShortName = !!shortName && dbShortName === shortName;
-      const sameName = !!name && dbName === name;
-
-      return sameCountry && (sameShortName || sameName);
-    });
-
-    if (existing?.id) {
-      console.log('Matched existing CTU in DB:', existing);
-      return of(existing.id);
-    }
-
-    const payload = {
-      shortName: selectedCtu?.shortName || null,
-      name: selectedCtu?.name || null,
-      country: countryIso2
-    };
-
-    console.log('CTU create payload =', payload);
-    console.log('selectedCtu =', selectedCtu);
-
-    if (!payload.country) {
       this.toastr.error('Unable to map CTU country from SharePoint to database country.');
       return of(null);
     }
 
-    return this.contextService.addCTU(payload).pipe(
+    const payload = {
+      sharepoint_item_id: ctuToResolve?.sharepointItemId || null,
+      name: ctuToResolve?.name || null,
+      short_name: ctuToResolve?.shortName || null,
+      country_iso2: countryIso2,
+      sas_verification: !!ctuToResolve?.sasVerification,
+      address_info: ctuToResolve?.addressInfo || null
+    };
+
+
+    return this.contextService.resolveSharePointCtu(payload).pipe(
       map((res: any) => {
-        console.log('CTU created =', res);
-        return res?.id || null;
+        return res?.id || fallbackDbId || null;
       }),
-      catchError((err) => {
-        console.log('CTU create error =', err);
-        console.log('CTU create error body =', err?.error);
-        this.toastr.error('Failed to create CTU');
+      catchError(() => {
+        if (fallbackDbId) {
+          return of(fallbackDbId);
+        }
+
+        this.toastr.error('Failed to resolve CTU from SharePoint.');
         return of(null);
       })
     );
@@ -407,6 +373,7 @@ export class UpsertStudyCtuComponent implements OnInit {
       for (const [i, fv] of this.fv.entries()) {
         const projectShortName = fv.study?.project?.shortName?.toLowerCase()?.trim();
         const ctuShortName = fv.ctu?.shortName?.toLowerCase()?.trim();
+
         if (projectShortName && ctuShortName && ctuEvaluations[projectShortName]) {
           this.ctuEvaluations[i] = ctuEvaluations[projectShortName].filter(
             (fields) => fields?.CTU?.toLowerCase() === ctuShortName
@@ -499,7 +466,7 @@ export class UpsertStudyCtuComponent implements OnInit {
     let patchForm = false;
 
     if (changes.studyCountry?.previousValue?.country?.iso2 != changes.studyCountry?.currentValue?.country?.iso2) {
-      if (this.sharePointCtus?.length > 0) {
+      if (this.displayCtus?.length > 0) {
         this.sortCTUs();
       }
       patchForm = true;
@@ -584,9 +551,9 @@ export class UpsertStudyCtuComponent implements OnInit {
     }
 
     if (payload.services?.length > 0) {
-      for (let i = 0; i < payload.services.length; i++) {
-        if (payload.services[i]?.id) {
-          payload.services[i] = payload.services[i].id;
+      for (let j = 0; j < payload.services.length; j++) {
+        if (payload.services[j]?.id) {
+          payload.services[j] = payload.services[j].id;
         }
       }
     } else {
@@ -604,14 +571,18 @@ export class UpsertStudyCtuComponent implements OnInit {
     const payload = JSON.parse(JSON.stringify(this.form.value));
 
     for (const [i, item] of payload.studyCTUs.entries()) {
+
       saveObs$.push(
         this.resolveCtuId(item.ctu).pipe(
           mergeMap((ctuId: number | null) => {
-            if (!ctuId) {
+            const finalCtuId = ctuId ?? item.ctu?.id;
+
+            if (!finalCtuId) {
+              console.error('No CTU ID resolved for item:', item);
               return of(false);
             }
 
-            item.ctu = { id: ctuId };
+            item.ctu = { id: finalCtuId };
             this.updatePayload(item, scId, studyId, i);
 
             let itemObs$: Observable<Object>;
@@ -623,6 +594,7 @@ export class UpsertStudyCtuComponent implements OnInit {
 
             return itemObs$.pipe(
               mergeMap((res: any) => {
+
                 if ((!item.id && res.statusCode === 201) || (item.id && res.statusCode === 200)) {
                   const subObs$: Observable<boolean>[] = [];
 
@@ -697,6 +669,7 @@ export class UpsertStudyCtuComponent implements OnInit {
     if (this.isFormValid()) {
       const studyId = this.form.value?.studyCTUs[0]?.study?.id;
       const scId = this.form.value?.studyCTUs[0]?.studyCountry?.id;
+
       if (scId && studyId) {
         this.onSave(scId, studyId).subscribe((success) => {
           this.spinner.hide();
@@ -714,6 +687,37 @@ export class UpsertStudyCtuComponent implements OnInit {
     }
   }
 
+  private mapExistingCtuToDisplayedCtu(ctu: any): any {
+    if (!ctu) {
+      return ctu;
+    }
+
+    const sharePointMatch = this.ctuMapperService.mapExistingCtuToDisplayedCtu(ctu, this.sharePointCtus);
+
+    if (sharePointMatch && (sharePointMatch?.sharepointItemId || sharePointMatch?.source === 'sharepoint')) {
+      return sharePointMatch;
+    }
+
+    return ctu;
+  }
+
+  private getSharePointVersionOfCtu(ctu: any): any {
+    if (!ctu) {
+      return null;
+    }
+
+    if (ctu?.sharepointItemId || ctu?.source === 'sharepoint') {
+      return ctu;
+    }
+
+    const match = this.sharePointCtus?.find((spCtu: any) => {
+      return this.ctuMapperService.compareCtuOptions(ctu, spCtu);
+    });
+
+
+    return match || null;
+  }
+
   dateToString(date) {
     return dateToString(date);
   }
@@ -723,31 +727,11 @@ export class UpsertStudyCtuComponent implements OnInit {
   }
 
   compareCtuOptions = (a: any, b: any): boolean => {
-    if (!a || !b) {
-      return a === b;
-    }
-
-    if (a.id && b.id) {
-      return a.id === b.id;
-    }
-
-    const aShort = this.normalizeText(a.shortName);
-    const bShort = this.normalizeText(b.shortName);
-    const aName = this.normalizeText(a.name);
-    const bName = this.normalizeText(b.name);
-    const aCountry = this.normalizeText(a?.country?.iso2 || a?.country?.name);
-    const bCountry = this.normalizeText(b?.country?.iso2 || b?.country?.name);
-
-    return aCountry === bCountry && ((aShort && aShort === bShort) || (aName && aName === bName));
+    return this.ctuMapperService.compareCtuOptions(a, b);
   };
 
   searchCTUs = (term: string, item: any) => {
-    const q = this.normalizeText(term);
-    const shortName = this.normalizeText(item?.shortName);
-    const name = this.normalizeText(item?.name);
-    const country = this.normalizeText(item?.country?.name || item?.country?.iso2);
-
-    return shortName.includes(q) || name.includes(q) || country.includes(q);
+    return this.ctuMapperService.searchCTUs(term, item);
   };
 
   back(): void {

--- a/src/app/pages/common/study/upsert-study/upsert-study.component.ts
+++ b/src/app/pages/common/study/upsert-study/upsert-study.component.ts
@@ -515,7 +515,7 @@ export class UpsertStudyComponent implements OnInit {
       }
     }
   }
-  
+
 
   back(): void {
     this.backService.back();

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,7 +1,7 @@
 import { appVersion } from './version';
 
-const baseUrl = 'https://api-crpmtdev.ecrin.org';  // No trailing slash
-// const baseUrl = 'http://localhost:8000';  // No trailing slash
+// const baseUrl = 'https://api-crpmtdev.ecrin.org';  // No trailing slash
+const baseUrl = 'http://localhost:8000';  // No trailing slash
 export const environment = {
   production: false,
   // Microsoft Entra

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,7 +1,7 @@
 import { appVersion } from './version';
 
-// const baseUrl = 'https://api-crpmtdev.ecrin.org';  // No trailing slash
-const baseUrl = 'http://localhost:8000';  // No trailing slash
+const baseUrl = 'https://api-crpmtdev.ecrin.org';  // No trailing slash
+// const baseUrl = 'http://localhost:8000';  // No trailing slash
 export const environment = {
   production: false,
   // Microsoft Entra


### PR DESCRIPTION
Fixes https://github.com/ecrin-github/crPMT/issues/20

- Fetch CTUs directly from SharePoint for dropdowns with fallback to DB CTUs
- Implement robust CTU matching logic between SharePoint and DB sources (using canonicalization for order-insensitive comparison of the name)
- Normalize country codes (ISO2/ISO3) to ensure consistent matching
- Automatically resolve SharePoint CTUs from DB CTUs without requiring user re-selection