### PR TITLE
linked N/A state between submissions and notifications using shared service

### DIFF
--- a/src/app/_rms/services/common/regulatory-link/regulatory-link.service.ts
+++ b/src/app/_rms/services/common/regulatory-link/regulatory-link.service.ts
@@ -55,22 +55,6 @@ export class RegulatoryLinkService {
     this.linksSubject.next(new Map(currentLinks));
   }
 
-  /**
-   * Legacy method - redirects to unified setNotApplicable
-   * @deprecated Use setNotApplicable instead
-   */
-  setSubmissionNotApplicable(studyCountryId: string, authority: string, notApplicable: boolean): void {
-    this.setNotApplicable(studyCountryId, authority, notApplicable, 'submission');
-  }
-
-  /**
-   * Legacy method - redirects to unified setNotApplicable
-   * @deprecated Use setNotApplicable instead
-   */
-  setNotificationNotApplicable(studyCountryId: string, authority: string, notApplicable: boolean): void {
-    this.setNotApplicable(studyCountryId, authority, notApplicable, 'notification');
-  }
-
   initializeFromData(studyCountryId: string, submissions: any[], notifications: any[]): void {
     const currentLinks = this.linksSubject.value;
 
@@ -123,5 +107,16 @@ export class RegulatoryLinkService {
   getNotificationNotApplicable(studyCountryId: string, authority: string): boolean {
     const link = this.getLink(studyCountryId, authority);
     return link?.notificationNotApplicable || false;
+  }
+
+  /**
+   * Remove a specific link to prevent phantom links
+   * Call this when an authority is changed or a submission/notification is deleted
+   */
+  removeLink(studyCountryId: string, authority: string): void {
+    const key = this.getKey(studyCountryId, authority);
+    const currentLinks = this.linksSubject.value;
+    currentLinks.delete(key);
+    this.linksSubject.next(new Map(currentLinks));
   }
 }

--- a/src/app/_rms/services/common/regulatory-link/regulatory-link.service.ts
+++ b/src/app/_rms/services/common/regulatory-link/regulatory-link.service.ts
@@ -1,0 +1,126 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+
+export interface RegulatoryLink {
+  studyCountryId: string;
+  authority: string;
+  submissionNotApplicable: boolean;
+  notificationNotApplicable: boolean;
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class RegulatoryLinkService {
+  private linksSubject = new BehaviorSubject<Map<string, RegulatoryLink>>(new Map());
+  public links$ = this.linksSubject.asObservable();
+
+  constructor() { }
+
+  private getKey(studyCountryId: string, authority: string): string {
+    return `${studyCountryId}_${authority}`;
+  }
+
+  getLink(studyCountryId: string, authority: string): RegulatoryLink | undefined {
+    const key = this.getKey(studyCountryId, authority);
+    return this.linksSubject.value.get(key);
+  }
+
+  setSubmissionNotApplicable(studyCountryId: string, authority: string, notApplicable: boolean): void {
+    const key = this.getKey(studyCountryId, authority);
+    const currentLinks = this.linksSubject.value;
+    const existingLink = currentLinks.get(key);
+
+    if (existingLink) {
+      existingLink.submissionNotApplicable = notApplicable;
+      // Sync notification N/A to match submission
+      existingLink.notificationNotApplicable = notApplicable;
+    } else {
+      const newLink: RegulatoryLink = {
+        studyCountryId,
+        authority,
+        submissionNotApplicable: notApplicable,
+        notificationNotApplicable: notApplicable // Sync to submission
+      };
+      currentLinks.set(key, newLink);
+    }
+
+    this.linksSubject.next(new Map(currentLinks));
+  }
+
+  setNotificationNotApplicable(studyCountryId: string, authority: string, notApplicable: boolean): void {
+    const key = this.getKey(studyCountryId, authority);
+    const currentLinks = this.linksSubject.value;
+    const existingLink = currentLinks.get(key);
+
+    if (existingLink) {
+      existingLink.notificationNotApplicable = notApplicable;
+      // Sync submission N/A to match notification
+      existingLink.submissionNotApplicable = notApplicable;
+    } else {
+      const newLink: RegulatoryLink = {
+        studyCountryId,
+        authority,
+        submissionNotApplicable: notApplicable, // Sync to notification
+        notificationNotApplicable: notApplicable
+      };
+      currentLinks.set(key, newLink);
+    }
+
+    this.linksSubject.next(new Map(currentLinks));
+  }
+
+  initializeFromData(studyCountryId: string, submissions: any[], notifications: any[]): void {
+    const currentLinks = this.linksSubject.value;
+
+    // Initialize from submissions
+    submissions.forEach(sub => {
+      const key = this.getKey(studyCountryId, sub.authority);
+      const existingLink = currentLinks.get(key);
+      if (!existingLink) {
+        currentLinks.set(key, {
+          studyCountryId,
+          authority: sub.authority,
+          submissionNotApplicable: sub.notApplicable || false,
+          notificationNotApplicable: false
+        });
+      } else {
+        // Update if not already set
+        if (existingLink.submissionNotApplicable === undefined) {
+          existingLink.submissionNotApplicable = sub.notApplicable || false;
+        }
+      }
+    });
+
+    // Initialize from notifications
+    notifications.forEach(notif => {
+      const key = this.getKey(studyCountryId, notif.authority);
+      const existingLink = currentLinks.get(key);
+      if (!existingLink) {
+        currentLinks.set(key, {
+          studyCountryId,
+          authority: notif.authority,
+          submissionNotApplicable: false,
+          notificationNotApplicable: notif.notApplicable || false
+        });
+      } else {
+        // Update if not already set
+        if (existingLink.notificationNotApplicable === undefined) {
+          existingLink.notificationNotApplicable = notif.notApplicable || false;
+        }
+      }
+    });
+
+    this.linksSubject.next(new Map(currentLinks));
+  }
+
+  getSubmissionNotApplicable(studyCountryId: string, authority: string): boolean {
+    const link = this.getLink(studyCountryId, authority);
+    return link?.submissionNotApplicable || false;
+  }
+
+  getNotificationNotApplicable(studyCountryId: string, authority: string): boolean {
+    const link = this.getLink(studyCountryId, authority);
+    return link?.notificationNotApplicable || false;
+  }
+}

--- a/src/app/_rms/services/common/regulatory-link/regulatory-link.service.ts
+++ b/src/app/_rms/services/common/regulatory-link/regulatory-link.service.ts
@@ -26,21 +26,28 @@ export class RegulatoryLinkService {
     return this.linksSubject.value.get(key);
   }
 
-  setSubmissionNotApplicable(studyCountryId: string, authority: string, notApplicable: boolean): void {
+  /**
+   * Set N/A state for either submission or notification (unified method)
+   * @param studyCountryId Study country identifier
+   * @param authority Authority name/code
+   * @param notApplicable N/A state to set
+   * @param source 'submission' or 'notification' - determines which field to update first
+   */
+  setNotApplicable(studyCountryId: string, authority: string, notApplicable: boolean, source: 'submission' | 'notification' = 'submission'): void {
     const key = this.getKey(studyCountryId, authority);
     const currentLinks = this.linksSubject.value;
     const existingLink = currentLinks.get(key);
 
     if (existingLink) {
+      // Update both fields to keep them in sync
       existingLink.submissionNotApplicable = notApplicable;
-      // Sync notification N/A to match submission
       existingLink.notificationNotApplicable = notApplicable;
     } else {
       const newLink: RegulatoryLink = {
         studyCountryId,
         authority,
         submissionNotApplicable: notApplicable,
-        notificationNotApplicable: notApplicable // Sync to submission
+        notificationNotApplicable: notApplicable
       };
       currentLinks.set(key, newLink);
     }
@@ -48,26 +55,20 @@ export class RegulatoryLinkService {
     this.linksSubject.next(new Map(currentLinks));
   }
 
+  /**
+   * Legacy method - redirects to unified setNotApplicable
+   * @deprecated Use setNotApplicable instead
+   */
+  setSubmissionNotApplicable(studyCountryId: string, authority: string, notApplicable: boolean): void {
+    this.setNotApplicable(studyCountryId, authority, notApplicable, 'submission');
+  }
+
+  /**
+   * Legacy method - redirects to unified setNotApplicable
+   * @deprecated Use setNotApplicable instead
+   */
   setNotificationNotApplicable(studyCountryId: string, authority: string, notApplicable: boolean): void {
-    const key = this.getKey(studyCountryId, authority);
-    const currentLinks = this.linksSubject.value;
-    const existingLink = currentLinks.get(key);
-
-    if (existingLink) {
-      existingLink.notificationNotApplicable = notApplicable;
-      // Sync submission N/A to match notification
-      existingLink.submissionNotApplicable = notApplicable;
-    } else {
-      const newLink: RegulatoryLink = {
-        studyCountryId,
-        authority,
-        submissionNotApplicable: notApplicable, // Sync to notification
-        notificationNotApplicable: notApplicable
-      };
-      currentLinks.set(key, newLink);
-    }
-
-    this.linksSubject.next(new Map(currentLinks));
+    this.setNotApplicable(studyCountryId, authority, notApplicable, 'notification');
   }
 
   initializeFromData(studyCountryId: string, submissions: any[], notifications: any[]): void {

--- a/src/app/pages/common/notification/upsert-notification/upsert-notification.component.html
+++ b/src/app/pages/common/notification/upsert-notification/upsert-notification.component.html
@@ -15,7 +15,7 @@
                                     <span class="text-value">{{NCA_TEXT}}</span>
                                 </ng-container>
                                 <ng-template #otherAuthority>
-                                    <input type="text" id="authority" class="form-control" formControlName="authority" *ngIf="!isView" />
+                                    <input type="text" id="authority" class="form-control" formControlName="authority" *ngIf="!isView" (input)="onAuthorityChange(i, $event.target.value)" />
                                     <span class="text-value" *ngIf="isView">{{notification.value.authority}}</span>
                                 </ng-template>
                             </ng-template>

--- a/src/app/pages/common/notification/upsert-notification/upsert-notification.component.ts
+++ b/src/app/pages/common/notification/upsert-notification/upsert-notification.component.ts
@@ -7,6 +7,7 @@ import { Observable, combineLatest, of } from 'rxjs';
 import { mergeMap } from 'rxjs/operators';
 import { NotificationInterface } from 'src/app/_rms/interfaces/core/notification.interface';
 import { NotificationService } from 'src/app/_rms/services/entities/notification/notification.service';
+import { RegulatoryLinkService } from 'src/app/_rms/services/common/regulatory-link/regulatory-link.service';
 import { dateToString, stringToDate } from 'src/assets/js/util';
 import { ConfirmationWindowComponent } from '../../confirmation-window/confirmation-window.component';
 import { AuthorityCodes, EC_TEXT, NCA_TEXT } from 'src/assets/js/constants';
@@ -18,6 +19,7 @@ import { AuthorityCodes, EC_TEXT, NCA_TEXT } from 'src/assets/js/constants';
 })
 export class UpsertNotificationComponent implements OnInit {
   @Input() notificationsData: Array<NotificationInterface>;
+  @Input() studyCountry: any;
 
   form: UntypedFormGroup;
   submitted: boolean = false;
@@ -38,6 +40,7 @@ export class UpsertNotificationComponent implements OnInit {
     private modalService: NgbModal,
     private router: Router,
     private notificationService: NotificationService,
+    private regulatoryLinkService: RegulatoryLinkService,
     private toastr: ToastrService) {
     this.form = this.fb.group({
       notifications: this.fb.array([])
@@ -48,6 +51,11 @@ export class UpsertNotificationComponent implements OnInit {
     this.isEdit = this.router.url.includes('edit');
     this.isView = this.router.url.includes('view');
     this.isAdd = this.router.url.includes('add');
+
+    // Subscribe to regulatory link changes
+    this.regulatoryLinkService.links$.subscribe(() => {
+      this.syncNotApplicableFromService();
+    });
   }
 
   get fc() { return this.form.get('notifications')["controls"]; }
@@ -230,6 +238,37 @@ export class UpsertNotificationComponent implements OnInit {
     if (this.fv[i]?.notApplicable) {
       this.getControls(i)?.notificationDate.setValue(null);
       this.getControls(i)?.comment?.setValue(null);
+    }
+
+    // Update regulatory link service
+    if (this.studyCountry?.id && this.fv[i]?.authority) {
+      this.regulatoryLinkService.setNotificationNotApplicable(
+        this.studyCountry.id,
+        this.fv[i].authority,
+        this.fv[i].notApplicable || false
+      );
+    }
+  }
+
+  private syncNotApplicableFromService() {
+    if (!this.studyCountry?.id) return;
+
+    for (let i = 0; i < this.fc.length; i++) {
+      const authority = this.fv[i]?.authority;
+      if (authority) {
+        const linkedNotApplicable = this.regulatoryLinkService.getNotificationNotApplicable(
+          this.studyCountry.id,
+          authority
+        );
+        if (this.fv[i].notApplicable !== linkedNotApplicable) {
+          this.getControls(i)?.notApplicable?.setValue(linkedNotApplicable);
+          // Don't call onChangeNotApplicable here to avoid recursion
+          if (linkedNotApplicable) {
+            this.getControls(i)?.notificationDate?.setValue(null);
+            this.getControls(i)?.comment?.setValue(null);
+          }
+        }
+      }
     }
   }
 

--- a/src/app/pages/common/notification/upsert-notification/upsert-notification.component.ts
+++ b/src/app/pages/common/notification/upsert-notification/upsert-notification.component.ts
@@ -38,6 +38,7 @@ export class UpsertNotificationComponent implements OnInit, OnDestroy {
   // Subjects for authority field debounce
   private authorityChanges$ = new Subject<{ index: number; authority: string }>();
   private destroy$ = new Subject<void>();
+  private previousAuthorities: Map<number, string> = new Map(); // Track previous authorities to clean up links
 
   constructor(
     private fb: UntypedFormBuilder,
@@ -148,7 +149,14 @@ export class UpsertNotificationComponent implements OnInit, OnDestroy {
 
   deleteNotification(i: number) {
     const nId = this.getNotificationsForm().value[i].id;
+    const authority = this.fv[i]?.authority;
+    
     if (!nId) { // Notification has been locally added only
+      // Clean up link for this authority
+      if (this.studyCountry?.id && authority) {
+        this.regulatoryLinkService.removeLink(this.studyCountry.id, authority);
+      }
+      this.previousAuthorities.delete(i);
       this.getNotificationsForm().removeAt(i);
     } else {  // Existing notification
       const removeModal = this.modalService.open(ConfirmationWindowComponent, { size: 'lg', backdrop: 'static' });
@@ -158,6 +166,11 @@ export class UpsertNotificationComponent implements OnInit, OnDestroy {
         if (remove) {
           this.notificationService.deleteNotification(nId).subscribe((res: any) => {
             if (res.status === 204) {
+              // Clean up link for this authority
+              if (this.studyCountry?.id && authority) {
+                this.regulatoryLinkService.removeLink(this.studyCountry.id, authority);
+              }
+              this.previousAuthorities.delete(i);
               this.getNotificationsForm().removeAt(i);
               this.toastr.success('Notification deleted successfully');
             } else {
@@ -305,6 +318,14 @@ export class UpsertNotificationComponent implements OnInit, OnDestroy {
    */
   private syncNotApplicableOnAuthorityChange(index: number, authority: string): void {
     if (!this.studyCountry?.id || !authority) return;
+
+    // Remove old authority link if it changed
+    const previousAuthority = this.previousAuthorities.get(index);
+    if (previousAuthority && previousAuthority !== authority) {
+      this.regulatoryLinkService.removeLink(this.studyCountry.id, previousAuthority);
+    }
+    // Track the new authority
+    this.previousAuthorities.set(index, authority);
 
     const linkedNotApplicable = this.regulatoryLinkService.getNotificationNotApplicable(
       this.studyCountry.id,

--- a/src/app/pages/common/notification/upsert-notification/upsert-notification.component.ts
+++ b/src/app/pages/common/notification/upsert-notification/upsert-notification.component.ts
@@ -1,10 +1,10 @@
-import { Component, Input, OnInit, SimpleChanges } from '@angular/core';
+import { Component, Input, OnInit, OnDestroy, SimpleChanges } from '@angular/core';
 import { UntypedFormArray, UntypedFormBuilder, UntypedFormGroup } from '@angular/forms';
 import { Router } from '@angular/router';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import { ToastrService } from 'ngx-toastr';
-import { Observable, combineLatest, of } from 'rxjs';
-import { mergeMap } from 'rxjs/operators';
+import { Observable, combineLatest, of, Subject } from 'rxjs';
+import { mergeMap, debounceTime, distinctUntilChanged, takeUntil } from 'rxjs/operators';
 import { NotificationInterface } from 'src/app/_rms/interfaces/core/notification.interface';
 import { NotificationService } from 'src/app/_rms/services/entities/notification/notification.service';
 import { RegulatoryLinkService } from 'src/app/_rms/services/common/regulatory-link/regulatory-link.service';
@@ -17,7 +17,7 @@ import { AuthorityCodes, EC_TEXT, NCA_TEXT } from 'src/assets/js/constants';
   templateUrl: './upsert-notification.component.html',
   styleUrls: ['./upsert-notification.component.scss']
 })
-export class UpsertNotificationComponent implements OnInit {
+export class UpsertNotificationComponent implements OnInit, OnDestroy {
   @Input() notificationsData: Array<NotificationInterface>;
   @Input() studyCountry: any;
 
@@ -34,6 +34,10 @@ export class UpsertNotificationComponent implements OnInit {
 
   truncate: boolean[] = [];
   notifications: NotificationInterface[] = [];
+
+  // Subjects for authority field debounce
+  private authorityChanges$ = new Subject<{ index: number; authority: string }>();
+  private destroy$ = new Subject<void>();
 
   constructor(
     private fb: UntypedFormBuilder,
@@ -56,6 +60,22 @@ export class UpsertNotificationComponent implements OnInit {
     this.regulatoryLinkService.links$.subscribe(() => {
       this.syncNotApplicableFromService();
     });
+
+    // Setup authority field changes with debounce for N/A sync
+    this.authorityChanges$
+      .pipe(
+        debounceTime(500), // Wait 500ms after user stops typing
+        distinctUntilChanged((prev, curr) => prev.index === curr.index && prev.authority === curr.authority),
+        takeUntil(this.destroy$)
+      )
+      .subscribe(({ index, authority }) => {
+        this.syncNotApplicableOnAuthorityChange(index, authority);
+      });
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
   }
 
   get fc() { return this.form.get('notifications')["controls"]; }
@@ -148,6 +168,7 @@ export class UpsertNotificationComponent implements OnInit {
           });
         }
       }, error => { this.toastr.error(error) });
+
     }
   }
 
@@ -235,19 +256,27 @@ export class UpsertNotificationComponent implements OnInit {
   }
 
   onChangeNotApplicable(i) {
+    // Clear related fields when N/A is checked
     if (this.fv[i]?.notApplicable) {
-      this.getControls(i)?.notificationDate.setValue(null);
-      this.getControls(i)?.comment?.setValue(null);
+      this.clearFieldsOnNotApplicable(i);
     }
 
     // Update regulatory link service
     if (this.studyCountry?.id && this.fv[i]?.authority) {
-      this.regulatoryLinkService.setNotificationNotApplicable(
+      this.regulatoryLinkService.setNotApplicable(
         this.studyCountry.id,
         this.fv[i].authority,
-        this.fv[i].notApplicable || false
+        this.fv[i].notApplicable || false,
+        'notification'
       );
     }
+  }
+
+  /**
+   * Handle authority field changes with debounce
+   */
+  onAuthorityChange(index: number, authority: string): void {
+    this.authorityChanges$.next({ index, authority });
   }
 
   private syncNotApplicableFromService() {
@@ -264,11 +293,40 @@ export class UpsertNotificationComponent implements OnInit {
           this.getControls(i)?.notApplicable?.setValue(linkedNotApplicable);
           // Don't call onChangeNotApplicable here to avoid recursion
           if (linkedNotApplicable) {
-            this.getControls(i)?.notificationDate?.setValue(null);
-            this.getControls(i)?.comment?.setValue(null);
+            this.clearFieldsOnNotApplicable(i);
           }
         }
       }
+    }
+  }
+
+  /**
+   * Sync N/A state when authority field changes (with debounce)
+   */
+  private syncNotApplicableOnAuthorityChange(index: number, authority: string): void {
+    if (!this.studyCountry?.id || !authority) return;
+
+    const linkedNotApplicable = this.regulatoryLinkService.getNotificationNotApplicable(
+      this.studyCountry.id,
+      authority
+    );
+
+    if (this.fv[index].notApplicable !== linkedNotApplicable) {
+      this.getControls(index)?.notApplicable?.setValue(linkedNotApplicable);
+      if (linkedNotApplicable) {
+        this.clearFieldsOnNotApplicable(index);
+      }
+    }
+  }
+
+  /**
+   * Clear all related fields when N/A checkbox is checked
+   */
+  private clearFieldsOnNotApplicable(i: number): void {
+    const controls = this.getControls(i);
+    if (controls) {
+      controls.notificationDate?.setValue(null);
+      controls.comment?.setValue(null);
     }
   }
 

--- a/src/app/pages/common/study-country/upsert-study-country/upsert-study-country.component.ts
+++ b/src/app/pages/common/study-country/upsert-study-country/upsert-study-country.component.ts
@@ -9,6 +9,7 @@ import { catchError, map, mapTo, mergeMap } from 'rxjs/operators';
 import { CountryInterface } from 'src/app/_rms/interfaces/context/country.interface';
 import { SafetyNotificationFormsInterface, SafetyNotificationInterface } from 'src/app/_rms/interfaces/core/safety-notification.interface';
 import { StudyCountryInterface } from 'src/app/_rms/interfaces/core/study-country.interface';
+import { StudyInterface } from 'src/app/_rms/interfaces/core/study.interface';
 import { BackService } from 'src/app/_rms/services/back/back.service';
 import { ContextService } from 'src/app/_rms/services/context/context.service';
 import { SafetyNotificationService } from 'src/app/_rms/services/entities/safety-notification/safety-notification.service';
@@ -21,7 +22,7 @@ import { UpsertSafetyNotificationComponent } from '../../safety-notification/ups
 import { UpsertStudyCtuComponent } from '../../study-ctu/upsert-study-ctu/upsert-study-ctu.component';
 import { UpsertSubmissionComponent } from '../../submission/upsert-submission/upsert-submission.component';
 import { AuthorityCodes, SafetyNotificationTypeCodes } from 'src/assets/js/constants';
-import { StudyInterface } from 'src/app/_rms/interfaces/core/study.interface';
+import { RegulatoryLinkService } from 'src/app/_rms/services/common/regulatory-link/regulatory-link.service';
 
 @Component({
   selector: 'app-upsert-study-country',
@@ -73,6 +74,7 @@ export class UpsertStudyCountryComponent implements OnInit {
     private spinner: NgxSpinnerService,
     public contextService: ContextService,
     private backService: BackService,
+    private regulatoryLinkService: RegulatoryLinkService,
     private toastr: ToastrService) {
     this.form = this.fb.group({
       studyCountries: this.fb.array([])
@@ -162,6 +164,13 @@ export class UpsertStudyCountryComponent implements OnInit {
 
   patchForm() {
     this.form.setControl('studyCountries', this.patchArray());
+
+    // Initialize regulatory links for each study country
+    this.studyCountries.forEach((sc, index) => {
+      const submissions = sc.submissions?.filter(sub => !sub.isAmendment && !sub.isOtherNotification) || [];
+      const notifications = sc.notifications || [];
+      this.regulatoryLinkService.initializeFromData(sc.id, submissions, notifications);
+    });
   }
 
   patchArray(): UntypedFormArray {

--- a/src/app/pages/common/submission/upsert-submission/upsert-submission.component.html
+++ b/src/app/pages/common/submission/upsert-submission/upsert-submission.component.html
@@ -15,7 +15,7 @@
                                     <span class="text-value">{{NCA_TEXT}}</span>
                                 </ng-container>
                                 <ng-template #otherAuthority>
-                                    <input type="text" id="authority" class="form-control" formControlName="authority" *ngIf="!isView" />
+                                    <input type="text" id="authority" class="form-control" formControlName="authority" *ngIf="!isView" (input)="onAuthorityChange(i, $event.target.value)" />
                                     <span class="text-value" *ngIf="isView">{{submission.value.authority}}</span>
                                 </ng-template>
                             </ng-template>

--- a/src/app/pages/common/submission/upsert-submission/upsert-submission.component.ts
+++ b/src/app/pages/common/submission/upsert-submission/upsert-submission.component.ts
@@ -1,10 +1,10 @@
-import { Component, Input, OnInit, SimpleChanges } from '@angular/core';
+import { Component, Input, OnInit, SimpleChanges, OnDestroy } from '@angular/core';
 import { UntypedFormArray, UntypedFormBuilder, UntypedFormGroup } from '@angular/forms';
 import { Router } from '@angular/router';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import { ToastrService } from 'ngx-toastr';
-import { Observable, combineLatest, of } from 'rxjs';
-import { mergeMap } from 'rxjs/operators';
+import { Observable, combineLatest, of, Subject } from 'rxjs';
+import { mergeMap, debounceTime, distinctUntilChanged, takeUntil } from 'rxjs/operators';
 import { SubmissionInterface } from 'src/app/_rms/interfaces/core/submission.interface';
 import { SubmissionService } from 'src/app/_rms/services/entities/submission/submission.service';
 import { RegulatoryLinkService } from 'src/app/_rms/services/common/regulatory-link/regulatory-link.service';
@@ -17,7 +17,7 @@ import { AuthorityCodes, EC_TEXT, NCA_TEXT } from 'src/assets/js/constants';
   templateUrl: './upsert-submission.component.html',
   styleUrls: ['./upsert-submission.component.scss']
 })
-export class UpsertSubmissionComponent implements OnInit {
+export class UpsertSubmissionComponent implements OnInit, OnDestroy {
   @Input() submissionsData: Array<SubmissionInterface>;
   @Input() isAmendments: boolean = false;
   @Input() isOthers: boolean = false;
@@ -36,6 +36,10 @@ export class UpsertSubmissionComponent implements OnInit {
 
   truncate: boolean[] = [];
   submissions: SubmissionInterface[] = [];
+
+  // Subject for authority field changes with debounce
+  private authorityChanges$ = new Subject<{ index: number; authority: string }>();
+  private destroy$ = new Subject<void>();
 
   constructor(
     private fb: UntypedFormBuilder,
@@ -58,6 +62,22 @@ export class UpsertSubmissionComponent implements OnInit {
     this.regulatoryLinkService.links$.subscribe(() => {
       this.syncNotApplicableFromService();
     });
+
+    // Setup authority field changes with debounce for N/A sync
+    this.authorityChanges$
+      .pipe(
+        debounceTime(500), // Wait 500ms after user stops typing
+        distinctUntilChanged((prev, curr) => prev.index === curr.index && prev.authority === curr.authority),
+        takeUntil(this.destroy$)
+      )
+      .subscribe(({ index, authority }) => {
+        this.syncNotApplicableOnAuthorityChange(index, authority);
+      });
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
   }
 
   get fc() { return this.form.get('submissions')["controls"]; }
@@ -255,21 +275,40 @@ export class UpsertSubmissionComponent implements OnInit {
   }
 
   onChangeNotApplicable(i) {
+    // Clear related fields when N/A is checked
     if (this.fv[i]?.notApplicable) {
-      this.getControls(i)?.submissionDate?.setValue(null);
-      this.getControls(i)?.approvalDate?.setValue(null);
-      this.getControls(i)?.protocolApprovalDate?.setValue(null);
-      this.getControls(i)?.protocolApprovedVersion?.setValue(null);
-      this.getControls(i)?.comment?.setValue(null);
+      this.clearFieldsOnNotApplicable(i);
     }
 
     // Update regulatory link service
     if (this.studyCountry?.id && this.fv[i]?.authority) {
-      this.regulatoryLinkService.setSubmissionNotApplicable(
+      this.regulatoryLinkService.setNotApplicable(
         this.studyCountry.id,
         this.fv[i].authority,
-        this.fv[i].notApplicable || false
+        this.fv[i].notApplicable || false,
+        'submission'
       );
+    }
+  }
+
+  /**
+   * Handle authority field changes with debounce
+   */
+  onAuthorityChange(index: number, authority: string): void {
+    this.authorityChanges$.next({ index, authority });
+  }
+
+  /**
+   * Clear all related fields when N/A checkbox is checked
+   */
+  private clearFieldsOnNotApplicable(i: number): void {
+    const controls = this.getControls(i);
+    if (controls) {
+      controls.submissionDate?.setValue(null);
+      controls.approvalDate?.setValue(null);
+      controls.protocolApprovalDate?.setValue(null);
+      controls.protocolApprovedVersion?.setValue(null);
+      controls.comment?.setValue(null);
     }
   }
 
@@ -287,13 +326,28 @@ export class UpsertSubmissionComponent implements OnInit {
           this.getControls(i)?.notApplicable?.setValue(linkedNotApplicable);
           // Don't call onChangeNotApplicable here to avoid recursion
           if (linkedNotApplicable) {
-            this.getControls(i)?.submissionDate?.setValue(null);
-            this.getControls(i)?.approvalDate?.setValue(null);
-            this.getControls(i)?.protocolApprovalDate?.setValue(null);
-            this.getControls(i)?.protocolApprovedVersion?.setValue(null);
-            this.getControls(i)?.comment?.setValue(null);
+            this.clearFieldsOnNotApplicable(i);
           }
         }
+      }
+    }
+  }
+
+  /**
+   * Sync N/A state when authority field changes (with debounce)
+   */
+  private syncNotApplicableOnAuthorityChange(index: number, authority: string): void {
+    if (!this.studyCountry?.id || !authority) return;
+
+    const linkedNotApplicable = this.regulatoryLinkService.getSubmissionNotApplicable(
+      this.studyCountry.id,
+      authority
+    );
+
+    if (this.fv[index].notApplicable !== linkedNotApplicable) {
+      this.getControls(index)?.notApplicable?.setValue(linkedNotApplicable);
+      if (linkedNotApplicable) {
+        this.clearFieldsOnNotApplicable(index);
       }
     }
   }

--- a/src/app/pages/common/submission/upsert-submission/upsert-submission.component.ts
+++ b/src/app/pages/common/submission/upsert-submission/upsert-submission.component.ts
@@ -7,6 +7,7 @@ import { Observable, combineLatest, of } from 'rxjs';
 import { mergeMap } from 'rxjs/operators';
 import { SubmissionInterface } from 'src/app/_rms/interfaces/core/submission.interface';
 import { SubmissionService } from 'src/app/_rms/services/entities/submission/submission.service';
+import { RegulatoryLinkService } from 'src/app/_rms/services/common/regulatory-link/regulatory-link.service';
 import { dateToString, stringToDate } from 'src/assets/js/util';
 import { ConfirmationWindowComponent } from '../../confirmation-window/confirmation-window.component';
 import { AuthorityCodes, EC_TEXT, NCA_TEXT } from 'src/assets/js/constants';
@@ -20,6 +21,7 @@ export class UpsertSubmissionComponent implements OnInit {
   @Input() submissionsData: Array<SubmissionInterface>;
   @Input() isAmendments: boolean = false;
   @Input() isOthers: boolean = false;
+  @Input() studyCountry: any;
 
   AuthorityCodes = AuthorityCodes;
   EC_TEXT = EC_TEXT;
@@ -40,6 +42,7 @@ export class UpsertSubmissionComponent implements OnInit {
     private modalService: NgbModal,
     private router: Router,
     private submissionService: SubmissionService,
+    private regulatoryLinkService: RegulatoryLinkService,
     private toastr: ToastrService) {
     this.form = this.fb.group({
       submissions: this.fb.array([])
@@ -50,6 +53,11 @@ export class UpsertSubmissionComponent implements OnInit {
     this.isEdit = this.router.url.includes('edit');
     this.isView = this.router.url.includes('view');
     this.isAdd = this.router.url.includes('add');
+
+    // Subscribe to regulatory link changes
+    this.regulatoryLinkService.links$.subscribe(() => {
+      this.syncNotApplicableFromService();
+    });
   }
 
   get fc() { return this.form.get('submissions')["controls"]; }
@@ -253,6 +261,40 @@ export class UpsertSubmissionComponent implements OnInit {
       this.getControls(i)?.protocolApprovalDate?.setValue(null);
       this.getControls(i)?.protocolApprovedVersion?.setValue(null);
       this.getControls(i)?.comment?.setValue(null);
+    }
+
+    // Update regulatory link service
+    if (this.studyCountry?.id && this.fv[i]?.authority) {
+      this.regulatoryLinkService.setSubmissionNotApplicable(
+        this.studyCountry.id,
+        this.fv[i].authority,
+        this.fv[i].notApplicable || false
+      );
+    }
+  }
+
+  private syncNotApplicableFromService() {
+    if (!this.studyCountry?.id) return;
+
+    for (let i = 0; i < this.fc.length; i++) {
+      const authority = this.fv[i]?.authority;
+      if (authority) {
+        const linkedNotApplicable = this.regulatoryLinkService.getSubmissionNotApplicable(
+          this.studyCountry.id,
+          authority
+        );
+        if (this.fv[i].notApplicable !== linkedNotApplicable) {
+          this.getControls(i)?.notApplicable?.setValue(linkedNotApplicable);
+          // Don't call onChangeNotApplicable here to avoid recursion
+          if (linkedNotApplicable) {
+            this.getControls(i)?.submissionDate?.setValue(null);
+            this.getControls(i)?.approvalDate?.setValue(null);
+            this.getControls(i)?.protocolApprovalDate?.setValue(null);
+            this.getControls(i)?.protocolApprovedVersion?.setValue(null);
+            this.getControls(i)?.comment?.setValue(null);
+          }
+        }
+      }
     }
   }
 

--- a/src/app/pages/common/submission/upsert-submission/upsert-submission.component.ts
+++ b/src/app/pages/common/submission/upsert-submission/upsert-submission.component.ts
@@ -40,6 +40,7 @@ export class UpsertSubmissionComponent implements OnInit, OnDestroy {
   // Subject for authority field changes with debounce
   private authorityChanges$ = new Subject<{ index: number; authority: string }>();
   private destroy$ = new Subject<void>();
+  private previousAuthorities: Map<number, string> = new Map(); // Track previous authorities to clean up links
 
   constructor(
     private fb: UntypedFormBuilder,
@@ -162,7 +163,14 @@ export class UpsertSubmissionComponent implements OnInit, OnDestroy {
 
   deleteSubmission(i: number) {
     const sId = this.getSubmissionsForm().value[i].id;
+    const authority = this.fv[i]?.authority;
+    
     if (!sId) { // Submission has been locally added only
+      // Clean up link for this authority
+      if (this.studyCountry?.id && authority) {
+        this.regulatoryLinkService.removeLink(this.studyCountry.id, authority);
+      }
+      this.previousAuthorities.delete(i);
       this.getSubmissionsForm().removeAt(i);
     } else {  // Existing submission
       const removeModal = this.modalService.open(ConfirmationWindowComponent, { size: 'lg', backdrop: 'static' });
@@ -172,6 +180,11 @@ export class UpsertSubmissionComponent implements OnInit, OnDestroy {
         if (remove) {
           this.submissionService.deleteSubmission(sId).subscribe((res: any) => {
             if (res.status === 204) {
+              // Clean up link for this authority
+              if (this.studyCountry?.id && authority) {
+                this.regulatoryLinkService.removeLink(this.studyCountry.id, authority);
+              }
+              this.previousAuthorities.delete(i);
               this.getSubmissionsForm().removeAt(i);
               this.toastr.success('Submission deleted successfully');
             } else {
@@ -338,6 +351,14 @@ export class UpsertSubmissionComponent implements OnInit, OnDestroy {
    */
   private syncNotApplicableOnAuthorityChange(index: number, authority: string): void {
     if (!this.studyCountry?.id || !authority) return;
+
+    // Remove old authority link if it changed
+    const previousAuthority = this.previousAuthorities.get(index);
+    if (previousAuthority && previousAuthority !== authority) {
+      this.regulatoryLinkService.removeLink(this.studyCountry.id, previousAuthority);
+    }
+    // Track the new authority
+    this.previousAuthorities.set(index, authority);
 
     const linkedNotApplicable = this.regulatoryLinkService.getSubmissionNotApplicable(
       this.studyCountry.id,


### PR DESCRIPTION
Fixes https://github.com/ecrin-github/crPMT/issues/60

- Added shared RegulatoryLinkService to synchronize N/A checkboxes between initial regulatory submissions and end-of-trial notifications