### PR TITLE
updated CTU mapping to new SharePoint field names

### DIFF
--- a/src/app/_rms/services/common/graph-api/graph-api.service.ts
+++ b/src/app/_rms/services/common/graph-api/graph-api.service.ts
@@ -132,6 +132,22 @@ export class GraphApiService {
     );
   }
 
+  /**
+   * Temporary debug helper: request the list of columns for the CTU Service Providers
+   * SharePoint list so we can inspect internal column names (used as $select values).
+   */
+  debugCTUColumns(): Observable<any> {
+    return this.getFullSiteId(this.SITE_NAME_QUALITY).pipe(
+      mergeMap((res: any) => {
+        if (res?.id) {
+          return this.http.get(
+            `https://graph.microsoft.com/v1.0/sites/${res.id}/lists/{${this.CTU_SERVICE_PROVIDERS_GUID}}/columns`
+          );
+        }
+        return of(null);
+      })
+    );
+  }
   setRiskRegisterData(res: any): void {
     let riskRegister: any[] = [];
 
@@ -335,14 +351,14 @@ export class GraphApiService {
       mergeMap((res: any) => {
         if (res?.id) {
           return this.http.get(
-            `https://graph.microsoft.com/v1.0/sites/${res.id}/lists/{${this.CTU_SERVICE_PROVIDERS_GUID}}/items?$expand=fields($select=Title,Short_x0020_Name,Country,SAS_x0020_Verification,Address)`
+            `https://graph.microsoft.com/v1.0/sites/${res.id}/lists/{${this.CTU_SERVICE_PROVIDERS_GUID}}/items?$expand=fields($select=Title,Short_x0020_Name,Country,SAS_x0020_Verification,AddressInfo,Contact,Contactemail,ContactTitle)`
           );
         }
         return of(null);
       })
     );
   }
-
+   
   getNonComplianceRegister(): Observable<any> {
     return this.getFullSiteId(this.SITE_NAME_QUALITY).pipe(
       mergeMap((res: any) => {
@@ -355,7 +371,6 @@ export class GraphApiService {
       })
     );
   }
-  
   setCTUsServiceProvidersData(res: any): void {
     let ctus: any[] = [];
 
@@ -364,19 +379,35 @@ export class GraphApiService {
         .map((item: any) => {
           const fields = item?.fields || {};
 
-          return {
+          // Extract contact information from SharePoint fields using discovered internal names
+          const contactName = fields?.Contact || '';
+          const contactEmail = fields?.Contactemail || '';
+          const contactTitle = fields?.ContactTitle || '';
+
+          const mapped = {
             id: null,
             sharepointItemId: item?.id || null,
             shortName: fields?.Short_x0020_Name || '',
             name: fields?.Title || '',
             sasVerification: !!fields?.SAS_x0020_Verification,
-            addressInfo: fields?.Address || null,
+            addressInfo: fields?.AddressInfo || null,
             country: {
               iso2: fields?.Country || null,
               name: fields?.Country || null
             },
+            // Build PersonInterface for contact
+            contact: contactName || contactEmail ? {
+              id: null,
+              country: null,
+              email: contactEmail || '',
+              isEuco: false,
+              fullName: contactName || '',
+              position: contactTitle || ''
+            } : null,
             source: 'sharepoint'
           };
+
+          return mapped;
         })
         .filter((ctu: any) => ctu.shortName || ctu.name);
     }

--- a/src/app/_rms/services/context/context.service.ts
+++ b/src/app/_rms/services/context/context.service.ts
@@ -246,6 +246,7 @@ export class ContextService {
     sas_verification: boolean;
     address_info: string | null;
   }): Observable<any> {
+    // payload logged during development; no debug log in production
     return this.http.post(`${environment.baseUrlApi}/context/ctus/resolve-sharepoint`, payload);
   }
 

--- a/src/app/_rms/services/entities/study-ctu/ctu-mapper.service.ts
+++ b/src/app/_rms/services/entities/study-ctu/ctu-mapper.service.ts
@@ -153,9 +153,19 @@ export class CtuMapperService {
     }
 
     const match = sharePointCtus.find((spCtu: any) => this.compareCtuOptions(ctu, spCtu, countries));
-    return match || ctu;
-  }
 
+    if (!match) {
+      return ctu;
+    }
+    // If SharePoint match lacks contact information, preserve the contact from the
+    // existing DB CTU to avoid losing user-entered or backend-stored contact data.
+    const merged = {
+      ...match,
+      contact: match.contact || ctu.contact,
+    };
+
+    return merged;
+  }
   /**
    * Convert a SharePoint country value to a DB ISO2 country code.
    */

--- a/src/app/pages/common/study-ctu/upsert-study-ctu/upsert-study-ctu.component.ts
+++ b/src/app/pages/common/study-ctu/upsert-study-ctu/upsert-study-ctu.component.ts
@@ -100,7 +100,6 @@ export class UpsertStudyCtuComponent implements OnInit {
     this.subscribeToCountries();
     this.subscribeToSharePointCtus();
     this.subscribeToServices();
-    // No temporary SharePoint inspection logs.
     if (this.isView) {
       this.subscribeToNonComplianceRegister();
     }

--- a/src/app/pages/common/study-ctu/upsert-study-ctu/upsert-study-ctu.component.ts
+++ b/src/app/pages/common/study-ctu/upsert-study-ctu/upsert-study-ctu.component.ts
@@ -100,6 +100,7 @@ export class UpsertStudyCtuComponent implements OnInit {
     this.subscribeToCountries();
     this.subscribeToSharePointCtus();
     this.subscribeToServices();
+    // No temporary SharePoint inspection logs.
     if (this.isView) {
       this.subscribeToNonComplianceRegister();
     }
@@ -177,6 +178,8 @@ export class UpsertStudyCtuComponent implements OnInit {
       // Keep only real SharePoint data here.
       this.sharePointCtus = ctus?.length > 0 ? [...ctus] : [];
 
+
+
       // Fix country ISO2 for SharePoint CTUs if they have ISO3 codes
       this.sharePointCtus.forEach(ctu => {
         if (ctu.country?.iso2 && this.countries?.length > 0) {
@@ -196,13 +199,15 @@ export class UpsertStudyCtuComponent implements OnInit {
         ? [...this.sharePointCtus]
         : [...this.dbCtus];
 
+      
+
       if (this.displayCtus?.length > 0) {
         this.sortCTUs();
 
         // Re-patch the form so existing DB CTUs can be replaced by
         // their SharePoint version when SharePoint data is available.
         if (this.studyCTUs?.length > 0) {
-          this.patchForm();
+
         }
       }
     });
@@ -297,13 +302,15 @@ export class UpsertStudyCtuComponent implements OnInit {
   patchArray(): UntypedFormArray {
     const formArray = new UntypedFormArray([]);
     this.studyCTUs.forEach((sctu) => {
+      const mappedCtu = this.mapExistingCtuToDisplayedCtu(sctu.ctu);
+
       formArray.push(this.fb.group({
         id: sctu.id,
         leadCtu: sctu.leadCtu,
         services: [sctu.services],
         study: sctu.study,
         studyCountry: sctu.studyCountry,
-        ctu: this.mapExistingCtuToDisplayedCtu(sctu.ctu),
+        ctu: mappedCtu,
         ctuAgreements: [sctu.ctuAgreements],
         centres: [sctu.centres]
       }));
@@ -353,6 +360,8 @@ export class UpsertStudyCtuComponent implements OnInit {
     // Always try to use the real SharePoint version when possible.
     const ctuToResolve = this.getSharePointVersionOfCtu(selectedCtu) || selectedCtu;
 
+    
+
     const countryIso2 = this.ctuMapperService.findCountryIso2FromSharePoint(ctuToResolve, this.countries);
 
     if (!countryIso2) {
@@ -372,6 +381,8 @@ export class UpsertStudyCtuComponent implements OnInit {
       sas_verification: !!ctuToResolve?.sasVerification,
       address_info: ctuToResolve?.addressInfo || null
     };
+
+    
 
 
     return this.contextService.resolveSharePointCtu(payload).pipe(
@@ -441,13 +452,11 @@ export class UpsertStudyCtuComponent implements OnInit {
         } else {
           this.ctuEvaluations[i] = [];
         }
-      }
-
+      }  
       this.sortCTUEvaluations();
       this.loadingCTUEvaluations = false;
     });
     this.loadingSASVerifications = true;
-
     this.graphApi.sasTracker$.subscribe((sasTracker: any) => {
       for (const [i, fv] of this.fv.entries()) {
         const ctuShortName = fv.ctu?.shortName?.toLowerCase()?.trim();
@@ -580,11 +589,13 @@ export class UpsertStudyCtuComponent implements OnInit {
     }
 
     if (changes.studyCTUsData) {
+      
       if (this.studyCTUsData === null) {
         this.studyCTUs = [];
       } else {
         this.studyCTUs = this.studyCTUsData;
       }
+      
       patchForm = true;
     }
 
@@ -691,6 +702,8 @@ export class UpsertStudyCtuComponent implements OnInit {
 
             item.ctu = { id: finalCtuId };
             this.updatePayload(item, scId, studyId, i);
+
+            
 
             let itemObs$: Observable<Object>;
             if (!item.id) {
@@ -801,11 +814,9 @@ export class UpsertStudyCtuComponent implements OnInit {
 
     const sharePointMatch = this.ctuMapperService.mapExistingCtuToDisplayedCtu(ctu, this.sharePointCtus, this.countries);
 
-    if (sharePointMatch && (sharePointMatch?.sharepointItemId || sharePointMatch?.source === 'sharepoint')) {
-      return sharePointMatch;
-    }
+    const returned = (sharePointMatch && (sharePointMatch?.sharepointItemId || sharePointMatch?.source === 'sharepoint')) ? sharePointMatch : ctu;
 
-    return ctu;
+    return returned;
   }
 
   private getSharePointVersionOfCtu(ctu: any): any {


### PR DESCRIPTION
Fixes https://github.com/ecrin-github/crPMT/issues/79

- Re-added CTU contact names in the CTU view(L4a-1.2 in the specs)
- Fixed SharePoint CTU mapping by using the correct internal column names (Contact, Contactemail, ContactTitle, AddressInfo) and preserved DB contact data as fallback when SharePoint contact fields are missing